### PR TITLE
added people to about, changed verbiage around site

### DIFF
--- a/src/components/pages/About.tsx
+++ b/src/components/pages/About.tsx
@@ -98,6 +98,10 @@ export default function About() {
                         <a href="mailto:rahul.arora@balliol.ox.ac.uk">rahul.arora@balliol.ox.ac.uk</a>
                         {Translate('AboutPage', ['ContactSection', 'BulletPointOne', 'PartTwo'], null, [true, true])}
                         <a href="mailto:tingting.yan@mail.utoronto.ca">tingting.yan@mail.utoronto.ca</a>.
+                        {Translate('AboutPage', ['ContactSection', 'BulletPointOne', 'PartThree'], null, [true, true])}
+                        <a href="mailto:media@covid19immunitytaskforce.ca">media@covid19immunitytaskforce.ca</a>
+                        {Translate('AboutPage', ['ContactSection', 'BulletPointOne', 'PartFour'], null, [true, true])}
+                        <a href="mailto:kelly.johnston2@ucalgary.ca">kelly.johnston2@ucalgary.ca</a>.
                     </p>
                     <p>
                         {Translate('AboutPage', ['ContactSection', 'BulletPointFive', 'PartOne'])}
@@ -163,6 +167,9 @@ export default function About() {
                     {renderBioBlock('David Buckeridge', [Translate('Biographies', ['DavidB', 'PartOne']), Translate('Biographies', ['DavidB', 'PartTwo'])])}
                     {renderBioBlock('Jesse Papenburg', [Translate('Biographies', ['Jesse', 'PartOne']), Translate('Biographies', ['Jesse', 'PartTwo'])])}
                     {renderBioBlock('Jonathan Chevrier', [Translate('Biographies', ['Jonathan', 'PartOne']), Translate('Biographies', ['Jonathan', 'PartTwo'])])}
+                    {renderBioBlock('Catherine Hankins', [Translate('Biographies', ['CatherineH', 'PartOne']), Translate('Biographies', ['CatherineH', 'PartTwo'])])}
+                    {renderBioBlock('Erin O\'Connor', [Translate('Biographies', ['ErinO', 'PartOne']), Translate('Biographies', ['ErinO', 'PartTwo'])])}
+                    {renderBioBlock('Catherine Eastwood', [Translate('Biographies', ['CatherineE', 'PartOne']), Translate('Biographies', ['CatherineE', 'PartTwo'])])}
                 </div>
             </div>
         </div>

--- a/src/components/pages/Data.tsx
+++ b/src/components/pages/Data.tsx
@@ -3,6 +3,7 @@ import { useMediaQuery } from "react-responsive";
 import { mobileDeviceOrTabletWidth } from "../../constants";
 import { sendAnalyticsEvent } from "../../utils/analyticsUtils";
 import Translate from "../../utils/translate/translateService";
+import { Link } from "react-router-dom";
 import './static.css';
 
 export default function Data() {
@@ -58,6 +59,10 @@ export default function Data() {
                 </p>
             </div>
             {renderAirtable('https://airtable.com/embed/shraXWPJ9Yu7ybowM?backgroundColor=blue&viewControls=on')}
+            <p>
+            {Translate('UseOfData')}
+            <Link className="p-1" to="/TermsOfUse">{Translate('TermsOfUse')}</Link>
+            </p>
         </div>
     )
 }

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -2,12 +2,25 @@ import React from "react";
 import "../sidebar.css";
 import AnalysisMethods from "./AnalysisMethods";
 import TotalStats from "./TotalStats";
+import HealthAgencyLogo from '../../../assets/images/public-health-agency.png';
+import UcalgaryLogo from '../../../assets/images/University-Of-Calgary-Logo.png';
 
 export default function LeftSidebar() {
   return (
     <div className="sidebar-container flex">
       <TotalStats/>
       <AnalysisMethods/>
+      <div className="m-3">
+          <a href="https://www.covid19immunitytaskforce.ca/" className="d-block mt-3 mx-auto" target="__blank" rel="noopener noreferrer">
+              <img src="https://www.covid19immunitytaskforce.ca/wp-content/themes/pena-lite-child/CITF_logo_ENG.svg" className="d-block mx-auto" alt="COVID-19 Immunity Task Force Logo" height="25"></img>
+          </a>
+          <a href="https://www.canada.ca/en/public-health.html/" className="d-block mt-3 mx-auto" target="__blank" rel="noopener noreferrer">
+              <img src={HealthAgencyLogo} className="d-block mx-auto" alt="Public Health Agency Logo" height="25"></img>
+          </a>
+          <a href="https://cumming.ucalgary.ca/centres/centre-health-informatics" className="d-block mt-3 mx-auto" target="__blank" rel="noopener noreferrer">
+              <img src={UcalgaryLogo} className="d-block mx-auto" alt="Centre for Health Informatics" height="22"></img>
+          </a>
+      </div>
     </div>
   )
 }

--- a/src/components/sidebar/right-sidebar/LastUpdated.tsx
+++ b/src/components/sidebar/right-sidebar/LastUpdated.tsx
@@ -11,7 +11,7 @@ export default function LastUpdated() {
     <div className="col-12 pb-2">
       <div className='col-12 p-0 center-item flex'>
         <div className="section-title center last-refreshed-title">
-        {Translate("ServerLastRefreshed").toUpperCase()}
+        {Translate("DatabaseUptoDateTo").toUpperCase()}
         </div>
       </div>
       <div className="py-2 center">

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -27,7 +27,9 @@
       },
       "BulletPointOne": {
         "PartOne": "For all SeroTracker inquiries (including to support our efforts, collaborate with us, or if you are a journalist interested in reporting on our findings), please contact Rahul Arora at ",
-        "PartTwo": "and Tingting Yan at "
+        "PartTwo": "and Tingting Yan at ",
+        "PartThree": "Journalists and members of the media: please contact Caroline Phaneuf at",
+        "PartFour": "and Kelly Johnston at"
       },
       "SectionOne": "We are an interdisciplinary team of researchers and engineers at the University of Oxford, University of Toronto, University of Waterloo, University of Calgary, and Harvard University."
     },
@@ -96,7 +98,7 @@
     "IgM": "IgM",
     "IgMIgG": "IgM IgG"
   },
-  "ServerLastRefreshed": "Server Last Refreshed",
+  "DatabaseUptoDateTo": "Database Up to Date To",
   "LancetArticle": "Lancet ID",
   "LastUpdatedTooltip": "SeroTracker is continuously updated with findings from newly-released serological studies. We include new studies from our search within 48 hours of publication.",
   "Location": "Location",
@@ -201,7 +203,7 @@
     "Unspecified": "Unspecified"
   },
   "Insights": "Insights",
-  "ScientificAdvisorsAndCollaborators": "Scientific Advisors and Collaborators",
+  "ScientificAdvisorsAndCollaborators": "Scientific Advisors and Project Staff",
   "ReportsAndArticles": "Reports & Articles",
   "Report": "Report",
   "ManuscriptAndPreprint": "Manuscript and Preprint",
@@ -315,15 +317,24 @@
       "PartOne": "Scientist, COVID-19 Immunity Task Force",
       "PartTwo": "Assistant Professor, McGill University"
     },
-    "Jonathan": {
-      "PartOne": "Scientific Program Manager, Epidemiology/Methods, COVID-19 Immunity Task Force",
-      "PartTwo": "Associate Professor, McGill University"
+    "CatherineH": {
+      "PartOne": "Co-Chair, COVID-19 Immunity Task Force",
+      "PartTwo": "Professor, McGill University"
+    },
+    "ErinO": {
+      "PartOne": "Project Lead, Centre for Health Informatics",
+      "PartTwo": "University of Calgary"
+    },
+    "CatherineE": {
+      "PartOne": "Operations Manager, Centre for Health Informatics",
+      "PartTwo": "Adjunct Assistant Professor, University of Calgary"
     }
   },
   "Today": "Today",
   "TotalEstimates": "Total Estimates",
   "TotalTests": "Total Tests",
   "UniversityOf": "University of NAME",
+  "UseOfData": "Use of this data is governed by SeroTracker's",
   "InitInfoModalText": {
     "PartOne": "Welcome to the SeroTracker Analyze tab! We are conducting a systematic review of SARS-CoV-2 serosurveys, and using the data from our review to build this dashboard.",
     "PartTwo": "Our dashboard aggregates seroprevalence estimates in each country. By default, these aggregated estimates include national and regional seroprevalence estimates of the general population or blood donors, and excludes estimates presented only in the news.",


### PR DESCRIPTION
It would be great to put small PHAC, CITF, and UCalgary logos (the same ones on the About page) on the Dashboard page, per a request from CITF yesterday. These can go in the bottom left of the Explore tab.
To reflect the dates that our data is up to date until: let's use the verbage "Database Up to Date To". This applies on the dashboard (bottom right, replacing 'server last refreshed); and above the AirTable embed.
To get the above date, can we automatically get the date of the last report that has been included in the database? Scrape the airtable for the most recent PUBLICATION_DATE and use that as the date for the above. This will require a little back-end work, but not much.
Can we link to our Terms of Use right above our AirTable embed, or right beside the button that ultimately links to the data download? Verbage: "Use of this data is governed by SeroTracker's Terms of Use" (with link)
Can we change Scientific Advisors and Collaborators on the site to Scientific Advisors and Project Staff, and add the following people to it? Catherine Hankins; Co-Chair, COVID-19 Immunity Task Force; Professor, McGill University. Erin O'Connor; Project Lead, Centre for Health Informatics; University of Calgary. Catherine Eastwood; Operations Manager, Centre for Health Informatics; Adjunct Assistant Professor, University of Calgary.
Media inquiries: can we change the verbage on the contact us page to add the line "Journalists and members of the media: please copy Caroline Phaneuf (mailto media@covid19immunitytaskforce.ca) and Kelly Johnston (mailto kelly.johnston2@ucalgary.ca)