### PR TITLE
No data analyze

### DIFF
--- a/src/components/charts/Charts.css
+++ b/src/components/charts/Charts.css
@@ -83,3 +83,16 @@ table thead tr::-webkit-scrollbar-thumb {
 .modal {
   z-index: 6000;
 }
+
+.no-data-container {
+  width: 100%;
+  height: 80%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.no-data-text {
+  font-size: 20px;
+}

--- a/src/components/charts/Charts.tsx
+++ b/src/components/charts/Charts.tsx
@@ -156,6 +156,7 @@ export default function Charts() {
               tooltipHeader={Translate("95%ConfidenceInterval")} />
           </div>
         </div>
+        {(records.length > 0) || (state.analyze.isLoading) ? 
         <ResponsiveContainer width="100%" height="80%">
           <BarChart data={records} layout='vertical' barGap={10}>
             <CartesianGrid strokeDasharray="3 3" />
@@ -166,9 +167,16 @@ export default function Charts() {
             <Bar isAnimationActive={false} dataKey="seroprevalence" name={`${Translate('Seroprevalence')} (%)`} fill="#55A6BA" maxBarSize={60} barSize={20}>
               <LabelList dataKey="seroprevalence" position="right" content={renderCustomizedLabel} />
               <ErrorBar dataKey="error" width={4} strokeWidth={2} />
-            </Bar>
+            </Bar>       
           </BarChart>
-        </ResponsiveContainer>
+        </ResponsiveContainer> : 
+        <div className="no-data-container">
+          <div>
+            <div className="no-data-text pb-1">{Translate('NoDataAnalyze', ['PartOne'])}</div> 
+            <div className="no-data-text">{Translate('NoDataAnalyze', ['PartTwo'])}</div>
+          </div>
+        </div>
+        }
       </div>
       <div className="container col-11 my-3 references">
         <ReferencesTable page={PageStateEnum.analyze} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,7 +82,7 @@ export type State = {
     language: LanguageType,
     showCookieBanner: boolean,
     showAnalyzePopup: boolean,
-    countries: any
+    countries: any,
     showEstimatePins: boolean
 };
 

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -220,6 +220,10 @@
   "NationalStudies": "National Studies",
   "NationalStudyDetails": "National study details",
   "NoData": "No Data",
+  "NoDataAnalyze": {
+    "PartOne":"No data is available for the filters you've specified.",
+    "PartTwo": "Please try a different filter combination."
+  },
   "NotReported": "Not Reported",
   "NumSeroprevalenceEstimates": "Number of Seroprevalence Estimates",
   "NumberEstimates": "Number of Estimates",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -222,6 +222,10 @@
     "StudyPins": "Afficher les lieux d'étude",
     "Sublocal": "Sous-local",
     "NoData": "Aucune donnée",
+    "NoDataAnalyze": {
+        "PartOne": "Il n'y a pas de données disponibles.",
+        "PartTwo": "Modifiez vos filtres pour visualizer des résultats."
+    },
     "NationalStudies": "Études nationale",
     "RegionalStudies": "Études régionale",
     "LocalStudies": "Études locale",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -223,8 +223,8 @@
     "Sublocal": "Sous-local",
     "NoData": "Aucune donnée",
     "NoDataAnalyze": {
-        "PartOne": "Il n'y a pas de données disponibles.",
-        "PartTwo": "Modifiez vos filtres pour visualizer des résultats."
+        "PartOne": "Il n'y pas de données correspondant a vos filtres.",
+        "PartTwo": "Veuillez modifier vos filtres et réessayer pour visualizer des résultats."
     },
     "NationalStudies": "Études nationale",
     "RegionalStudies": "Études régionale",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Analyze tab looks wonky when filter combinations that return no data are set by the user.

## Please link the Airtable ticket associated with this PR.

https://airtable.com/tbli2lWQHAqBa6ZcI/viw7Tba8QVTJ49F4v/reckRZBzQOxlvkvmd

## If applicable, include screenshots of the feature/bugfix introduced by this PR.

![image](https://user-images.githubusercontent.com/21212898/107154225-cee67d00-693f-11eb-8326-52f7b2895413.png)

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Ran the webapp locally, visited analyze tab, added filters that should return no data.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

https://github.com/serotracker/iit-backend/pull/152
