### PR TITLE
sampling naming change

### DIFF
--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -142,8 +142,8 @@ export default class httpClient {
         const [startDate, endDate] = formatDates(date)
         const reqBody = {
             filters: reqBodyFilters,
-            start_date: startDate,
-            end_date: endDate,
+            sampling_start_date: startDate,
+            sampling_end_date: endDate,
             sorting_key: sorting_key,
             reverse: reverse,
             per_page: null,
@@ -202,8 +202,8 @@ export default class httpClient {
         const date = filters['publish_date']        
         const [startDate, endDate] = formatDates(date)
         const reqBody = {
-            start_date: startDate,
-            end_date: endDate,
+            sampling_start_date: startDate,
+            sampling_end_date: endDate,
             filters: reqBodyFilters
         }
 
@@ -261,8 +261,8 @@ export default class httpClient {
         delete reqBodyFilters['publish_date'];
         const [startDate, endDate] = formatDates(date)
         const reqBody = {
-            start_date: startDate,
-            end_date: endDate,
+            sampling_start_date: startDate,
+            sampling_end_date: endDate,
             filters: reqBodyFilters,
             aggregation_variable,
             meta_analysis_technique,

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,8 +153,8 @@ export type PostRecordsBody = {
         specimen_type: String[],
         estimate_grade: String[]
     },
-    start_date: Date | null,
-    end_date: Date | null,
+    sampling_start_date: Date | null,
+    sampling_end_date: Date | null,
     sorting_key: String,
     reverse: Boolean,
     per_page: Number,


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Changes of the following filter option names:
start_date --> sampling_start_date
end_date --> sampling_end_date

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.
Simona's filter changes
