### PR TITLE
Who map compliance mapbox

### DIFF
--- a/src/components/map/Layers/Countries.tsx
+++ b/src/components/map/Layers/Countries.tsx
@@ -58,6 +58,7 @@ const Countries = (map: mapboxgl.Map | undefined, estimateGradePrevalences: Esti
 
     const [state] = useContext(AppContext);
     const [popup, setPopup] = useState<mapboxgl.Popup | undefined>(undefined);
+    const [currentFeatureId, setCurrentFeatureId] = useState<string | undefined>(undefined);
 
     // If estimates are updated, waits until map is loaded then maps estimate data to country features
     useEffect(() => {
@@ -103,16 +104,30 @@ const Countries = (map: mapboxgl.Map | undefined, estimateGradePrevalences: Esti
             });
 
             map.on("mousemove", "Countries", function (e: any) {
-                if (e.features[0].state.hasData && countryPop.isOpen()) {
+                const f = e.features[0];
+                if (f.state.hasData && f.id !== currentFeatureId && countryPop.isOpen()) {
                     countryPop
                     .setLngLat(e.lngLat)
                     .setHTML(ReactDOMServer.renderToString(CountryPopup(e.features[0], state.language)))
+                    setCurrentFeatureId(f.id);
                 }
             });
 
             setPopup(countryPop);
         }
-    }, [map, state.language, popup])
+    }, [map, state.language, popup, currentFeatureId])
+
+    useEffect(()=>{
+        if(popup !== undefined){
+            if (state.showCountryHover){
+                popup.removeClassName("disable-popup")
+            }
+            else
+            {
+                popup.addClassName("disable-popup")
+            }
+        }
+    }, [popup, state.showCountryHover])
 
     return;
 }

--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -26,15 +26,15 @@ const StudyPins = (map: mapboxgl.Map | undefined, records: AirtableRecord[], sho
     }
     else if (map && map.getLayer("study-pins")) {
       map.setLayoutProperty("study-pins", 'visibility', showEstimatePins ? 'visible' : 'none');
-    }
 
-    var onlyGuid: (string | null)[] = records.map((r) => { return r.source_id })
+      var onlyGuid: (string | null)[] = records.map((r) => { return r.source_id })
 
     map?.setFilter('study-pins',
       ["in",
         ['get', 'source_id'],
         ["literal", onlyGuid]
       ]);
+    }
   }, [map, records, showEstimatePins]);
 
   useEffect(() => {

--- a/src/components/map/Legend.css
+++ b/src/components/map/Legend.css
@@ -56,6 +56,10 @@
   width: 14.2857%;
 }
 
+.circleBase {
+  border-radius: 50%;
+}
+
 h4.legend-title:hover {
   position: relative;
 }

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -17,24 +17,28 @@ export default function Legend() {
     <div className={isMobileDeviceOrTablet ? "info flex legend-mobile center-item" : "info flex legend center-item"}>
       <div className="flex legend-container" key={Math.random()}>
         <div className="legend-item cursor" onClick={clickEstimatePinsCheckbox}>
-          <i className="block"><input className="checkbox" type="checkbox" checked={state.showEstimatePins} /></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-2"}>{Translate("StudyPins")}</p>
+          <i className="circleBase"><input className="checkbox" type="checkbox" checked={state.showEstimatePins} /></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("StudyPins")}</p>
         </div>
         <div className="legend-item">
-          <i className="block" style={{ background: MapSymbology.StudyFeature.National.Color }}></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-2"}>{Translate("NationalStudies")}</p>
+          <i className="circleBase" style={{ background: MapSymbology.StudyFeature.National.Color }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("NationalStudies")}</p>
         </div>
         <div className="legend-item">
-          <i className="block" style={{ background: MapSymbology.StudyFeature.Regional.Color }}></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-2"}>{Translate("RegionalStudies")}</p>
+          <i className="circleBase" style={{ background: MapSymbology.StudyFeature.Regional.Color }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("RegionalStudies")}</p>
         </div>
         <div className="legend-item">
-          <i className="block" style={{ background: MapSymbology.StudyFeature.Local.Color }}></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-2"}>{Translate("LocalStudies")}</p>
+          <i className="circleBase" style={{ background: MapSymbology.StudyFeature.Local.Color }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("LocalStudies")}</p>
         </div>
         <div className="legend-item">
-          <i className="block" style={{ background: MapSymbology.CountryFeature.HasData.Color }}></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-2"}>{Translate("CountryEstimatesExist")}</p>
+          <i className="block" style={{ background: MapSymbology.CountryFeature.HasData.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("CountryEstimatesExist")}</p>
+        </div>
+        <div className="legend-item">
+          <i className="block" style={{ background: MapSymbology.CountryFeature.Default.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("CountryEstimatesNotExist")}</p>
         </div>
       </div>
     </div>

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -42,7 +42,7 @@ export default function Legend() {
         </div>
         <div className="legend-item">
           <i className="block" style={{ background: MapSymbology.CountryFeature.Disputed.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>
-          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("Not Applicable")}</p>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("NotApplicable")}</p>
         </div>
       </div>
     </div>

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -7,7 +7,7 @@ import Translate from "../../utils/translate/translateService";
 import { MapSymbology } from "components/map/MapConfig"
 
 interface LegendProps {
-  
+  layers: string[]
 }
 
 export default function Legend(props: LegendProps) {

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -40,6 +40,10 @@ export default function Legend() {
           <i className="block" style={{ background: MapSymbology.CountryFeature.Default.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>
           <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("CountryEstimatesNotExist")}</p>
         </div>
+        <div className="legend-item">
+          <i className="block" style={{ background: MapSymbology.CountryFeature.Disputed.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>
+          <p className={isMobileDeviceOrTablet ? "mobile-text px-2" : "px-1"}>{Translate("Not Applicable")}</p>
+        </div>
       </div>
     </div>
   )

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -6,11 +6,7 @@ import "./Legend.css";
 import Translate from "../../utils/translate/translateService";
 import { MapSymbology } from "components/map/MapConfig"
 
-interface LegendProps {
-  layers: string[]
-}
-
-export default function Legend(props: LegendProps) {
+export default function Legend() {
   const [state, dispatch] = useContext(AppContext);
   const isMobileDeviceOrTablet = useMediaQuery({ maxWidth: mobileDeviceOrTabletWidth })
   const clickEstimatePinsCheckbox = (e: React.MouseEvent<HTMLElement>) => {

--- a/src/components/map/MapConfig.ts
+++ b/src/components/map/MapConfig.ts
@@ -26,6 +26,10 @@ export const MapSymbology = {
             Color: '#97b1bd',
             Opacity: 0.5 
         },
+        Disputed: {
+            Color: '#E1E1E1',
+            Opacity: 1 
+        },
         Default: {
             Color: '#FFFFFF',
             Opacity: 0 

--- a/src/components/map/MapboxMap.css
+++ b/src/components/map/MapboxMap.css
@@ -60,3 +60,7 @@ div.ReactModal__Overlay.ReactModal__Overlay--after-open.slide-pane__overlay.some
 .mapboxgl-popup-anchor-top-left .mapboxgl-popup-tip{
     display:none !important;
 }
+
+.disable-popup {
+  display:none !important;
+}

--- a/src/components/map/MapboxMap.tsx
+++ b/src/components/map/MapboxMap.tsx
@@ -7,10 +7,9 @@ import StudyPins from "components/map/Layers/StudyPins";
 import { MapUrlResource } from 'components/map/MapConfig'
 // @ts-ignore
 // eslint-disable-next-line
-import mapboxgl from '!mapbox-gl';
+import mapboxgl, { Style } from '!mapbox-gl';
 import "components/map/MapboxMap.css";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { State } from "types";
 
 // @ts-ignore
 // eslint-disable-next-line import/no-webpack-loader-syntax
@@ -21,28 +20,26 @@ mapboxgl.accessToken = process.env.REACT_APP_MAPBOX_API_KEY as string;
 function mapOnLoad(map: mapboxgl.Map, dispatch: Dispatch<any>) {
   getEsriVectorSourceStyle(MapUrlResource.WHO_COUNTRY_VECTORTILES).then((style: mapboxgl.Style) => {
     addEsriLayersFromVectorSourceStyle(style, map);
-    const styleJson: any = map.getStyle();
+    const styleJson: Style = map.getStyle();
+    let CountryPolygonsMoved = false;
     if (styleJson && styleJson.layers) {
-      for (let layer of styleJson.layers) {
-        const t = layer["source-layer"];
-        if (t === "DISPUTED_AREAS") {
-          map.moveLayer("Countries", layer.id); // HACK for now, moves countries layer behind border once loaded.
-          break;
+      for (let layer of styleJson.layers as any) {
+        const source = layer["source-layer"];
+        if (source === "DISPUTED_AREAS") {
+          if (!CountryPolygonsMoved)
+          {
+            map.moveLayer("Countries", layer.id); // HACK for now, moves countries layer behind border once loaded.
+          }
+
+          map.on("mouseenter", layer.id, function (e: any) {
+            dispatch({ type: 'HIDE_COUNTRY_HOVER' })
+          });
+          map.on("mouseleave", layer.id, function (e: any) {
+            dispatch({ type: 'SHOW_COUNTRY_HOVER' })
+          });
         }
       }
     }
-
-    map.on("mousemove", "Boundaries/DISPUTED BORDERS AND AREAS/DISPUTED_AREAS/Aksai Chin_1", function (e: any) {
-      if (e.features[0].state.hasData) {
-        dispatch({ type: 'SHOW_COUNTRY_HOVER' })
-      }
-    });
-
-    map.on("mousemove", "DISPUTED_AREAS", function (e: any) {
-      if (e.features[0].state.hasData) {
-        dispatch({ type: 'SHOW_COUNTRY_HOVER' })
-      }
-    });
   });
 }
 

--- a/src/components/map/MapboxMap.tsx
+++ b/src/components/map/MapboxMap.tsx
@@ -47,8 +47,10 @@ const MapboxGLMap = (): any => {
         //@ts-ignore
         container: mapContainerRef.current,
         style: baseMapStyle,
-        center: [0, 30],
-        zoom: 1,
+        center: [10, 30],
+        zoom: 2,
+        attributionControl: false,
+        antialias: true// enables MSAA antialiasing, to help make dotted line WHO borders more visible
       });
 
       m.on("load", () => {
@@ -68,7 +70,7 @@ const MapboxGLMap = (): any => {
   return (
     //@ts-ignore
     <div className="mapContainer w-100" ref={(el) => (mapContainerRef.current = el)}>
-      <Legend />
+      <Legend layers={state.MapLayers}/>
     </div>
   );
 };

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -83,11 +83,21 @@ const initialState: State = {
   showAnalyzePopup: true,
   countries : [],
   showEstimatePins: true,
-  MapLayers: []
+  showCountryHover:true,
 };
 
 const reducer = (state: State, action: Record<string, any>): State => {
   switch (action.type) {
+    case "SHOW_COUNTRY_HOVER":
+      return {
+        ...state,
+        showCountryHover: true
+      };
+    case "HIDE_COUNTRY_HOVER":
+      return {
+        ...state,
+        showCountryHover: false
+      };
     case "TOGGLE_ESTIMATE_PINS":
       return {
         ...state,

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -82,7 +82,8 @@ const initialState: State = {
   showCookieBanner: false,
   showAnalyzePopup: true,
   countries : [],
-  showEstimatePins: true
+  showEstimatePins: true,
+  MapLayers: []
 };
 
 const reducer = (state: State, action: Record<string, any>): State => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,7 +84,8 @@ export type State = {
     showCookieBanner: boolean,
     showAnalyzePopup: boolean,
     countries: any,
-    showEstimatePins: boolean
+    showEstimatePins: boolean,
+    MapLayers: any
 };
 
 export type StartDates = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export type State = {
     showAnalyzePopup: boolean,
     countries: any,
     showEstimatePins: boolean,
-    MapLayers: any
+    showCountryHover: boolean,
 };
 
 export type StartDates = {

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -118,6 +118,7 @@
   "CountriesAndAreas": "Countries and Areas",
   "CountryEstimatesExist": "Seroprevalence Estimates",
   "CountryEstimatesNotExist": "No Seroprevalence Estimates",
+  "Not Applicable": "Not Applicable",
   "CountryOptions": {
     "England": "England",
     "Iran": "Iran",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -116,7 +116,7 @@
   "Countries": "Countries",
   "CountriesIncluded": "Countries Included",
   "CountriesAndAreas": "Countries and Areas",
-  "CountryEstimatesExist": "Countries With Seroprevalence Estimates",
+  "CountryEstimatesExist": "Countries and areas with Seroprevalence Estimates",
   "CountryOptions": {
     "England": "England",
     "Iran": "Iran",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -118,7 +118,7 @@
   "CountriesAndAreas": "Countries and Areas",
   "CountryEstimatesExist": "Seroprevalence Estimates",
   "CountryEstimatesNotExist": "No Seroprevalence Estimates",
-  "Not Applicable": "Not Applicable",
+  "NotApplicable": "Not Applicable",
   "CountryOptions": {
     "England": "England",
     "Iran": "Iran",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -116,7 +116,8 @@
   "Countries": "Countries",
   "CountriesIncluded": "Countries Included",
   "CountriesAndAreas": "Countries and Areas",
-  "CountryEstimatesExist": "Countries and areas with Seroprevalence Estimates",
+  "CountryEstimatesExist": "Seroprevalence Estimates",
+  "CountryEstimatesNotExist": "No Seroprevalence Estimates",
   "CountryOptions": {
     "England": "England",
     "Iran": "Iran",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -115,6 +115,7 @@
     "CountriesIncluded": "Pays inclus",
     "CountriesAndAreas": "Pays et régions",
     "CountryEstimatesExist": "Pays dotés d'estimations de séroprévalence",
+    "CountryEstimatesNotExist": "",
     "CountryOptions": {
         "England": "Angleterre",
         "Iran": "Iran",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -116,7 +116,7 @@
     "CountriesAndAreas": "Pays et régions",
     "CountryEstimatesExist": "Pays dotés d'estimations de séroprévalence",
     "CountryEstimatesNotExist": "",
-    "Not Applicable": "",
+    "NotApplicable": "",
     "CountryOptions": {
         "England": "Angleterre",
         "Iran": "Iran",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -116,6 +116,7 @@
     "CountriesAndAreas": "Pays et régions",
     "CountryEstimatesExist": "Pays dotés d'estimations de séroprévalence",
     "CountryEstimatesNotExist": "",
+    "Not Applicable": "",
     "CountryOptions": {
         "England": "Angleterre",
         "Iran": "Iran",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
The WHO feedback as per their email:

    Legend : Given that the oPt is depicted using the “Country with seroprevalence estimates” grey, the corresponding item in the legend should read “Countries and areas with seroprevalence estimates”.
        The “not applicable” grey item should be included

    Summary statistics (top left side of the page): if the 73 “countries included” includes the oPt and other areas such as French Guyana, this should be changed to read “countries and areas included: 73” 

    Jammu&Kashmir: the dotted line of control is missing

    Aksai Chin: we would suggest avoiding to display the box reporting data for “China” when placing the cursor over Aksai Chin. This is because, as signaled by its colorization, this area is disputed.

    Kenya/South Sudan border: the dashed triangle is missing 

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

![image](https://user-images.githubusercontent.com/22464147/110418357-a8a62100-8054-11eb-89be-2537cd49614d.png)
Updated legend icon styling to match visual representation on the map

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.
