### PR TITLE
Fix Filtering

### DIFF
--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -36,25 +36,21 @@ const StudyPins = (map: mapboxgl.Map | undefined, records: AirtableRecord[]) => 
   const prevSelectedPinId = usePrevious(selectedPinId)
 
   useEffect(() => {
-    if (map && records.length > 0 && map.getLayer("study-pins") === undefined) {
+    if(map){
       const src = generateSourceFromRecords(records);
-      map.addSource("study-pins", src);
-      map.addLayer({
-        id: "study-pins",
-        type: "circle",
-        source: "study-pins",
-        paint: MapConfig.Studies as mapboxgl.CirclePaint
-      });
-    }
-    else if (map && map.getLayer("study-pins")) {
-
-      var onlyGuid: (string | null)[] = records.map((r) => { return r.source_id })
-
-    map?.setFilter('study-pins',
-      ["in",
-        ['get', 'source_id'],
-        ["literal", onlyGuid]
-      ]);
+      if(map.getLayer("study-pins") === undefined){
+        map.addSource("study-pins", src);
+        map.addLayer({
+          id: "study-pins",
+          type: "circle",
+          source: "study-pins",
+          paint: MapConfig.Studies as mapboxgl.CirclePaint
+        });
+      }
+      else{
+        const studyPinsSource = map.getSource("study-pins") as any;
+        studyPinsSource.setData(src.data);
+      }
     }
   }, [map, records]);
 


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Bug description per slack message: It seems initial load is the only time we are actually generating a study pins layer. When the user applies filters, we simply apply a Mapbox client side filter on the study pins layer to only include study pins with IDs matching the IDs returned from our API. The problem with this approach is that it assumes that the records in the initial response is a superset of the records from any filtered response. This is a false assumption due to estimate prioritization (EP). EP aims to select the most representative estimate for a given study given certain filter params. As such, EP may select some top level estimate for the study when no filters are applied, but select a different estimate to represent that study when we provide a filter.

- Solution: Use Mapbox's setData function to fully update the map's source object whenever we get filtered records back instead of using mapbox filtering.

## Please link the Airtable ticket associated with this PR.

https://airtable.com/tbli2lWQHAqBa6ZcI/viwWvxb27XGuziw4c/recY2QuH55NZAzgVd?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

N/A

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Locally -> ensured that filtering behaviour was as expected (single filter and combinations of filters), ensured that there were no regressions (nothing broke when filtering yielded no results, estimate grade checkboxes still worked, etc)

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

N/A
