### PR TITLE
Fixed Google Analytics events not sending to dashboard

### DIFF
--- a/src/utils/analyticsUtils.tsx
+++ b/src/utils/analyticsUtils.tsx
@@ -13,11 +13,10 @@ interface eventSenderProps {
   action: string
 }
 
-let cookieAcceptance = false;
-
 export const sendAnalyticsEvent = (props: eventSenderProps) => {
+  const cookieAcceptance = localStorage.getItem('acceptedCookies');
   if (cookieAcceptance) {
-    ReactGA.event(props)
+    ReactGA.event(props);
   }
 }
 interface Props {


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Google Analytics events were not being sent to our dashboard for over a year because of a small mistake we missed...

## Please link the Airtable ticket associated with this PR.
https://airtable.com/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/rechJLXHFeThfYOi8?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Download Google Analytics debugger
- Set local environment variable to include our Google Analytics project tracking id
- Look at dashboard while clicking around locally

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.
- Nope!

## Does this PR require any French translations? Have they been included?
- Nope!
