### PR TITLE
Unity studies filter

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,7 +156,7 @@ function App() {
         </Route>
         <Route path="/:language/Unity">
           <Explore initialFilters={(() => {
-            const initialFilters = getEmptyFilters();
+            let initialFilters = getEmptyFilters();
             initialFilters.unity_aligned_only = true;
             return initialFilters;
           })()}/>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,9 @@ import { CookieBanner } from "./components/shared/CookieBanner";
 import { NavBar } from "./components/shared/NavBar";
 import { Footer } from "./components/shared/Footer";
 import TableauEmbed from "./components/shared/TableauEmbed";
-import { AppContext } from "./context";
+import { AppContext, getEmptyFilters } from "./context";
 import httpClient from "./httpClient";
 import { LanguageType, PageStateEnum } from "./types";
-import { initializeData } from "./utils/stateUpdateUtils";
 import { setLanguageType } from "./utils/translate/translateService";
 import { ANALYZE_URLS, CANADA_URLS } from "./constants";
 
@@ -26,8 +25,7 @@ function App() {
 
   // General call that happens once at the start of everything.
   useEffect(() => {
-    const api = new httpClient()
-    initializeData(dispatch, explore.filters, PageStateEnum.explore)
+    const api = new httpClient();
     const allFilterOptions = async () => {
       const { options, updatedAt, maxDate, minDate } = await api.getAllFilterOptions();
       dispatch({
@@ -155,6 +153,13 @@ function App() {
         </Route>
         <Route path="/:language/Publications">
           <Publications />
+        </Route>
+        <Route path="/:language/Unity">
+          <Explore initialFilters={(() => {
+            const initialFilters = getEmptyFilters();
+            initialFilters.unity_aligned_only = true;
+            return initialFilters;
+          })()}/>
         </Route>
         <Redirect exact from="/" to={`/${language}/Explore`} />
         {language && ["About", "Explore", "Analyze", "Data", "PrivacyPolicy", "CookiePolicy", "TermsOfUse", "Publications", "Canada"].map(route =>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ function App() {
   // General call that happens once at the start of everything.
   useEffect(() => {
     const api = new httpClient()
-    initializeData(dispatch, explore.filters, true, PageStateEnum.explore)
+    initializeData(dispatch, explore.filters, PageStateEnum.explore)
     const allFilterOptions = async () => {
       const { options, updatedAt, maxDate, minDate } = await api.getAllFilterOptions();
       dispatch({

--- a/src/components/map/Legend.css
+++ b/src/components/map/Legend.css
@@ -34,7 +34,7 @@ label {
   width: 15px !important;
 }
 
-.checkbox {
+.legend-checkbox {
   margin-left: auto;
 }
 

--- a/src/components/map/Legend.tsx
+++ b/src/components/map/Legend.tsx
@@ -26,17 +26,17 @@ export default function Legend() {
       <div className="legend-item" id="National" onClick={handleLegendToggle}>
         <i className="circleBase legend-icon" style={{ background: MapSymbology.StudyFeature.National.Color }}></i>
         <label>{Translate("NationalStudies")}</label>
-        <input className="ui checkbox" type="checkbox" checked={state.explore.legendLayers.National} readOnly />
+        <input className="ui checkbox legend-checkbox" type="checkbox" checked={state.explore.legendLayers.National} readOnly />
       </div>
       <div className="legend-item" id="Regional" onClick={handleLegendToggle}>
         <i className="circleBase legend-icon" style={{ background: MapSymbology.StudyFeature.Regional.Color }}></i>
         <label>{Translate("RegionalStudies")}</label>
-        <input className="ui checkbox" type="checkbox" checked={state.explore.legendLayers.Regional} readOnly />
+        <input className="ui checkbox legend-checkbox" type="checkbox" checked={state.explore.legendLayers.Regional} readOnly />
       </div>
       <div className="legend-item mb-1" id="Local" onClick={handleLegendToggle}>
         <i className="circleBase legend-icon" style={{ background: MapSymbology.StudyFeature.Local.Color }}></i>
         <label>{Translate("LocalStudies")}</label>
-        <input className="ui checkbox" type="checkbox" checked={state.explore.legendLayers.Local} readOnly />
+        <input className="ui checkbox legend-checkbox" type="checkbox" checked={state.explore.legendLayers.Local} readOnly />
       </div>
       <div className="legend-item">
         <i className="block legend-icon" style={{ background: MapSymbology.CountryFeature.HasData.Color, outlineWidth: 1, outlineStyle: "solid" }}></i>

--- a/src/components/pages/Dashboard/Explore.tsx
+++ b/src/components/pages/Dashboard/Explore.tsx
@@ -15,20 +15,6 @@ export default function Explore() {
   const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth });
   const [state, dispatch] = useContext(AppContext)
 
-  useEffect(() => {
-    dispatch({
-      type: "UPDATE_EXPLORE_IS_OPEN",
-      payload: true
-    })
-    return () => {
-      dispatch({
-        type: "UPDATE_EXPLORE_IS_OPEN",
-        payload: false
-      })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
   return (
     <>
       <div className="fill flex dashboard">

--- a/src/components/pages/Dashboard/Explore.tsx
+++ b/src/components/pages/Dashboard/Explore.tsx
@@ -3,17 +3,40 @@ import { useMediaQuery } from "react-responsive";
 import { Loader } from "semantic-ui-react";
 import { isMaintenanceMode, mobileDeviceOrTabletWidth } from "../../../constants";
 import { AppContext } from "../../../context";
-import { PageStateEnum } from "../../../types";
+import { PageStateEnum, Filters } from "../../../types";
 import MapboxMap from '../../map/MapboxMap';
 import MobileComponents from '../../mobile/ExploreMobile';
 import MaintenanceModal from "../../shared/MaintenanceModal";
 import LeftSidebar from "../../sidebar/left-sidebar/LeftSidebar";
 import RightSidebar from "../../sidebar/right-sidebar/RightSidebar";
 import Legend from "components/map/Legend";
+import { initializeData } from "../../../utils/stateUpdateUtils";
+import httpClient from "../../../httpClient";
 
-export default function Explore() {
+interface ExploreProps {
+  initialFilters?: Filters;
+}
+
+export default function Explore(props: ExploreProps) {
   const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth });
-  const [state, dispatch] = useContext(AppContext)
+  const [state, dispatch] = useContext(AppContext);
+
+  // Apply initial input filters and get records
+  useEffect(() => {
+    if(props.initialFilters){
+      dispatch({
+        type: 'UPDATE_ALL_FILTERS',
+        payload: {
+          newFilters: props.initialFilters,
+          pageStateEnum: PageStateEnum.explore
+        }
+      });
+    }
+    const api = new httpClient();
+    initializeData(dispatch, state.explore.filters, PageStateEnum.explore)
+    // We only want this to run once so we pass no dependencies. Do not remove this
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <>

--- a/src/components/shared/InformationIcon.tsx
+++ b/src/components/shared/InformationIcon.tsx
@@ -24,6 +24,7 @@ export default function InformationIcon(props: InformationIconProps) {
         offset={offset}
         position={position}
         size={popupSize}
+        hoverable={true}
         onOpen={() => {
           sendAnalyticsEvent({
             /** Typically the object that was interacted with (e.g. 'Video') */

--- a/src/components/shared/InformationIcon.tsx
+++ b/src/components/shared/InformationIcon.tsx
@@ -24,7 +24,7 @@ export default function InformationIcon(props: InformationIconProps) {
         offset={offset}
         position={position}
         size={popupSize}
-        hoverable={true}
+        hoverable
         onOpen={() => {
           sendAnalyticsEvent({
             /** Typically the object that was interacted with (e.g. 'Video') */

--- a/src/components/sidebar/right-sidebar/Filters.css
+++ b/src/components/sidebar/right-sidebar/Filters.css
@@ -1,0 +1,6 @@
+.checkbox-item {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin: 0.2em;
+}

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -130,14 +130,26 @@ export default function Filters({ page }: FilterProps) {
                   tooltip_text={
                   <div>
                     <p>{Translate('StudyInformationTooltip', ['FirstParagraph'])}</p>
-                    <p>{Translate('StudyInformationTooltip', ['SecondParagraph'])}</p>
+                    <p>
+                      <b>{Translate('StudyInformationTooltip', ['SecondParagraph', 'PartOne'])}</b>
+                      {Translate('StudyInformationTooltip', ['SecondParagraph', 'PartTwo'])}
+                    </p>
+                    <p>
+                      <b>{Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartOne'])}</b>
+                      {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartTwo'])}
+                      <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/early-investigations" 
+                      target="_blank" rel="noopener noreferrer">
+                        {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartThree'])}
+                      </a>
+                      {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartFour'])}
+                    </p>
                   </div>
                   }
                 />
               }
             </div>
             <div>
-              {buildFilterCheckbox('unity_aligned_only', 'Show WHO Unity Aligned Studies')}
+              {buildFilterCheckbox('unity_aligned_only', Translate('ShowUnityStudies'))}
             </div>
             <div>
               {buildFilterDropdown('source_type', Translate('SourceType'))}

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -8,6 +8,7 @@ import { toPascalCase } from "../../../utils/translate/caseChanger";
 import Translate, { getCountryName } from "../../../utils/translate/translateService";
 import InformationIcon from "../../shared/InformationIcon";
 import SectionHeader from "./SectionHeader";
+import Datepicker from "./datepicker/Datepicker";
 
 interface FilterProps {
   page: string
@@ -54,22 +55,13 @@ export default function Filters({ page }: FilterProps) {
   }
 
   const addFilter = async (data: any, filterType: FilterType) => {
-    dispatch({
-      type: 'UPDATE_FILTER',
-      payload: {
-        filterType,
-        filterValue: data.value,
-        pageStateEnum: page
-      }
-    });
     await updateFilters(
       dispatch,
       pageState.filters,
       filterType,
-      data.value,
+      data,
       state.dataPageState.exploreIsOpen,
-      page,
-      state.chartAggregationFactor)
+      page)
   }
 
   const buildFilterDropdown = (filter_type: FilterType, placeholder: string) => {
@@ -84,7 +76,7 @@ export default function Filters({ page }: FilterProps) {
           selection
           options={formatOptions(state.allFilterOptions[filter_type], filter_type)}
           onChange={async (e: any, data: any) => {
-            await addFilter(data, filter_type)
+            await addFilter(new Set(data.value), filter_type)
             sendAnalyticsEvent({
               /** Typically the object that was interacted with (e.g. 'Video') */
               category: 'Filter',
@@ -97,6 +89,20 @@ export default function Filters({ page }: FilterProps) {
           }}
           defaultValue={getFilters(filter_type)}
         />
+      </div>
+    )
+  }
+
+  const buildFilterCheckbox = (filter_type: FilterType, label: string) => {
+    return(
+      <div className="legend-item" id="National" onClick={async (e: React.MouseEvent<HTMLElement>) => {
+        await addFilter(
+          !pageState.filters[filter_type], 
+          filter_type
+        )
+      }}>
+        <label>{label}</label>
+        <input className="ui checkbox" type="checkbox" checked={pageState.filters[filter_type]} readOnly />
       </div>
     )
   }
@@ -140,6 +146,9 @@ export default function Filters({ page }: FilterProps) {
             <div>
               {buildFilterDropdown('overall_risk_of_bias', Translate('OverallRiskOfBias'))}
             </div>
+            <div>
+              {buildFilterCheckbox('unity_aligned_only', 'Show WHO Unity aligned studies')}
+            </div>
           </div>
           <div className="pb-1">
             <div>
@@ -171,6 +180,7 @@ export default function Filters({ page }: FilterProps) {
           </div>
         </div>
       </div>
+      <Datepicker page={page}/>
     </div>
   )
 }

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -131,15 +131,15 @@ export default function Filters({ page }: FilterProps) {
                   <div>
                     <p>{Translate('StudyInformationTooltip', ['FirstParagraph'])}</p>
                     <p>
-                      <b>{Translate('StudyInformationTooltip', ['SecondParagraph', 'PartOne'])}</b>
+                      <b>{Translate('StudyInformationTooltip', ['SecondParagraph', 'PartOne'], null, [false, true])}</b>
                       {Translate('StudyInformationTooltip', ['SecondParagraph', 'PartTwo'])}
                     </p>
                     <p>
-                      <b>{Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartOne'])}</b>
-                      {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartTwo'])}
+                      <b>{Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartOne'], null, [false, true])}</b>
+                      {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartTwo'], null, [false, true])}
                       <a href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/early-investigations" 
                       target="_blank" rel="noopener noreferrer">
-                        {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartThree'])}
+                        {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartThree'], null, [false, true])}
                       </a>
                       {Translate('StudyInformationTooltip', ['ThirdParagraph', 'PartFour'])}
                     </p>

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -19,10 +19,6 @@ export default function Filters({ page }: FilterProps) {
   const [state, dispatch] = useContext(AppContext);
   const pageState = state[page as keyof State] as PageState;
 
-  const getFilters = (filter_type: FilterType): string[] => {
-    return Array.from(pageState.filters[filter_type]) as string[]
-  }
-
   const formatOptions = (options: any, filter_type: FilterType) => {
     if (!options) {
       return
@@ -61,7 +57,6 @@ export default function Filters({ page }: FilterProps) {
       pageState.filters,
       filterType,
       data,
-      state.dataPageState.exploreIsOpen,
       page)
   }
 
@@ -77,7 +72,7 @@ export default function Filters({ page }: FilterProps) {
           selection
           options={formatOptions(state.allFilterOptions[filter_type], filter_type)}
           onChange={async (e: any, data: any) => {
-            await addFilter(new Set(data.value), filter_type)
+            await addFilter(data.value, filter_type)
             sendAnalyticsEvent({
               /** Typically the object that was interacted with (e.g. 'Video') */
               category: 'Filter',
@@ -88,7 +83,7 @@ export default function Filters({ page }: FilterProps) {
               /** A numeric value associated with the event (e.g. 42) */
             })
           }}
-          defaultValue={getFilters(filter_type)}
+          defaultValue={pageState.filters[filter_type] as string[]}
         />
       </div>
     )
@@ -102,7 +97,7 @@ export default function Filters({ page }: FilterProps) {
           filter_type
         )
       }}>
-        <input className="ui checkbox" type="checkbox" checked={pageState.filters[filter_type]} readOnly />
+        <input className="ui checkbox" type="checkbox" checked={pageState.filters[filter_type] as boolean} readOnly />
         <label>{label}</label>
       </div>
     )

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -89,9 +89,9 @@ export default function Filters({ page }: FilterProps) {
     )
   }
 
-  const buildFilterCheckbox = (filter_type: FilterType, label: string) => {
+  const buildFilterCheckbox = (filter_type: FilterType, label: string, title?: string) => {
     return(
-      <div className="checkbox-item pb-3" id="National" onClick={async (e: React.MouseEvent<HTMLElement>) => {
+      <div title={title ? title: label} className="checkbox-item pb-3" id="National" onClick={async (e: React.MouseEvent<HTMLElement>) => {
         await addFilter(
           !pageState.filters[filter_type], 
           filter_type
@@ -149,7 +149,7 @@ export default function Filters({ page }: FilterProps) {
               }
             </div>
             <div>
-              {buildFilterCheckbox('unity_aligned_only', Translate('ShowUnityStudies'))}
+              {buildFilterCheckbox('unity_aligned_only', Translate('UnityStudiesOnly'), Translate('UnityStudiesOnlyLong'))}
             </div>
             <div>
               {buildFilterDropdown('source_type', Translate('SourceType'))}

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -9,6 +9,7 @@ import Translate, { getCountryName } from "../../../utils/translate/translateSer
 import InformationIcon from "../../shared/InformationIcon";
 import SectionHeader from "./SectionHeader";
 import Datepicker from "./datepicker/Datepicker";
+import "./Filters.css";
 
 interface FilterProps {
   page: string
@@ -95,14 +96,14 @@ export default function Filters({ page }: FilterProps) {
 
   const buildFilterCheckbox = (filter_type: FilterType, label: string) => {
     return(
-      <div className="legend-item" id="National" onClick={async (e: React.MouseEvent<HTMLElement>) => {
+      <div className="checkbox-item pb-3" id="National" onClick={async (e: React.MouseEvent<HTMLElement>) => {
         await addFilter(
           !pageState.filters[filter_type], 
           filter_type
         )
       }}>
-        <label>{label}</label>
         <input className="ui checkbox" type="checkbox" checked={pageState.filters[filter_type]} readOnly />
+        <label>{label}</label>
       </div>
     )
   }
@@ -141,13 +142,13 @@ export default function Filters({ page }: FilterProps) {
               }
             </div>
             <div>
+              {buildFilterCheckbox('unity_aligned_only', 'Show WHO Unity Aligned Studies')}
+            </div>
+            <div>
               {buildFilterDropdown('source_type', Translate('SourceType'))}
             </div>
             <div>
               {buildFilterDropdown('overall_risk_of_bias', Translate('OverallRiskOfBias'))}
-            </div>
-            <div>
-              {buildFilterCheckbox('unity_aligned_only', 'Show WHO Unity aligned studies')}
             </div>
           </div>
           <div className="pb-1">

--- a/src/components/sidebar/right-sidebar/RightSidebar.tsx
+++ b/src/components/sidebar/right-sidebar/RightSidebar.tsx
@@ -13,7 +13,6 @@ export default function RightSidebar({page}: SideBarProps) {
     <div className="justify-content-between fill sidebar-container right-sidebar">
       <div className="filters-container mb-3">
         <Filters page={page}/>
-        <Datepicker page={page}/>
       </div>
     </div>
   )

--- a/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
+++ b/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
@@ -41,8 +41,7 @@ export default function Datepicker({ page }: DatepickerProps) {
       "publish_date" as FilterType,
       newDates,
       state.dataPageState.exploreIsOpen,
-      page,
-      state.chartAggregationFactor)
+      page)
   }
 
   const CustomInput = ({ value, onClick, text }: any) => (

--- a/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
+++ b/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
@@ -16,7 +16,7 @@ interface DatepickerProps {
 export default function Datepicker({ page }: DatepickerProps) {
   const [state, dispatch] = useContext(AppContext);
   const pageState = state[page as keyof State] as PageState;
-  const [filterStartDate, filterEndDate] = Array.from(pageState.filters.publish_date);
+  const [filterStartDate, filterEndDate] = pageState.filters.publish_date;
   const [startDate, setStartDate] = useState(filterStartDate);
   const [endDate, setEndDate] = useState(filterEndDate);
 

--- a/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
+++ b/src/components/sidebar/right-sidebar/datepicker/Datepicker.tsx
@@ -40,7 +40,6 @@ export default function Datepicker({ page }: DatepickerProps) {
       pageState.filters,
       "publish_date" as FilterType,
       newDates,
-      state.dataPageState.exploreIsOpen,
       page)
   }
 

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -17,8 +17,9 @@ export function getEmptyFilters(): Filters {
     overall_risk_of_bias: new Set(),
     isotypes_reported: new Set(),
     specimen_type: new Set(),
-    publish_date: new Set([initialMinDate, initialMaxDate]),
+    publish_date: [initialMinDate, initialMaxDate],
     estimate_grade: new Set(),
+    unity_aligned_only: false
   };
 }
 
@@ -116,7 +117,7 @@ const reducer = (state: State, action: Record<string, any>): State => {
       const { pageStateEnum, filterType, filterValue } = action.payload;
       const newState = { ...state };
       const pageState = newState[pageStateEnum as keyof State] as PageState;
-      pageState.filters[filterType as FilterType] = new Set(filterValue);
+      pageState.filters[filterType as FilterType] = filterValue;
       return newState;
     }
 

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -8,17 +8,17 @@ const initialMaxDate = new Date();
 
 export function getEmptyFilters(): Filters {
   return {
-    source_type: new Set(),
-    test_type: new Set(),
-    country: new Set(),
-    population_group: new Set(),
-    sex: new Set(),
-    age: new Set(),
-    overall_risk_of_bias: new Set(),
-    isotypes_reported: new Set(),
-    specimen_type: new Set(),
+    source_type: [],
+    test_type: [],
+    country: [],
+    population_group: [],
+    sex: [],
+    age: [],
+    overall_risk_of_bias: [],
+    isotypes_reported: [],
+    specimen_type: [],
     publish_date: [initialMinDate, initialMaxDate],
-    estimate_grade: new Set(),
+    estimate_grade: [],
     unity_aligned_only: false
   };
 }
@@ -42,9 +42,6 @@ const initialState: State = {
   // representing the data page once
   // we put filters there
   allFilterOptions: getEmptyFilters(),
-  dataPageState: {
-    exploreIsOpen: true,
-  },
   calendarStartDates: {
     // Important, the fact that we use an hour here tells us that we are using a default value
     minDate: initialMinDate,
@@ -139,14 +136,6 @@ const reducer = (state: State, action: Record<string, any>): State => {
     }
     case "UPDATE_AGGREGATION_FACTOR":
       return { ...state, chartAggregationFactor: action.payload };
-    case "UPDATE_EXPLORE_IS_OPEN":
-      return {
-        ...state,
-        dataPageState: {
-          ...state.dataPageState,
-          exploreIsOpen: action.payload,
-        },
-      };
     case "TOGGLE_NATIONAL_PIN_LAYER": {
       return {
         ...state,

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -117,6 +117,13 @@ const reducer = (state: State, action: Record<string, any>): State => {
       pageState.filters[filterType as FilterType] = filterValue;
       return newState;
     }
+    case "UPDATE_ALL_FILTERS": {
+      const { pageStateEnum, newFilters } = action.payload;
+      const newState = { ...state };
+      const pageState = newState[pageStateEnum as keyof State] as PageState;
+      pageState.filters = newFilters;
+      return newState;
+    }
 
     case "MAX_MIN_DATES":
       const { minDate, maxDate } = action.payload;

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type Filters = {
   specimen_type: any;
   publish_date: any;
   estimate_grade: any;
+  unity_aligned_only: boolean;
 };
 
 export type FilterType =
@@ -68,7 +69,8 @@ export type FilterType =
   | "overall_risk_of_bias"
   | "isotypes_reported"
   | "specimen_type"
-  | "estimate_grade";
+  | "estimate_grade"
+  | "unity_aligned_only";
 
 export enum LanguageType {
   french = "fr",

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,8 +42,6 @@ export type AggregatedRecord = {
   seroprevalence: number;
 };
 
-// Each filter will be a javascript set
-// TODO: find typing to represent sets
 export type Filters = {
   source_type: string[];
   test_type: string[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,17 +45,17 @@ export type AggregatedRecord = {
 // Each filter will be a javascript set
 // TODO: find typing to represent sets
 export type Filters = {
-  source_type: any;
-  test_type: any;
-  country: any;
-  population_group: any;
-  sex: any;
-  age: any;
-  overall_risk_of_bias: any;
-  isotypes_reported: any;
-  specimen_type: any;
-  publish_date: any;
-  estimate_grade: any;
+  source_type: string[];
+  test_type: string[];
+  country: string[];
+  population_group: string[];
+  sex: string[];
+  age: string[];
+  overall_risk_of_bias: string[];
+  isotypes_reported: string[];
+  specimen_type: string[];
+  publish_date: Date[];
+  estimate_grade: string[];
   unity_aligned_only: boolean;
 };
 
@@ -89,7 +89,6 @@ export type State = {
   allFilterOptions: Filters;
   updatedAt: string;
   calendarStartDates: StartDates;
-  dataPageState: DataPageState;
   language: LanguageType;
   showCookieBanner: boolean;
   countries: any;
@@ -148,35 +147,3 @@ export enum AggregationFactor {
   overall_risk_of_bias = "overall_risk_of_bias",
   isotypes_reported = "isotypes_reported",
 }
-
-export type DataPageState = {
-  exploreIsOpen: boolean;
-};
-
-export type CustomMatcherResult = {
-  pass: boolean;
-  message: string;
-};
-
-export type PostRecordsBody = {
-  filters: {
-    country: String[];
-    source_type: String[];
-    source_name: String[];
-    overall_risk_of_bias: String[];
-    population_group: String[];
-    age: String[];
-    sex: String[];
-    test_type: String[];
-    isotypes_reported: String[];
-    specimen_type: String[];
-    estimate_grade: String[];
-  };
-  sampling_start_date: Date | null;
-  sampling_end_date: Date | null;
-  sorting_key: String;
-  reverse: Boolean;
-  per_page: Number;
-  page_index: Number;
-  columns: String[];
-};

--- a/src/utils/stateUpdateUtils.tsx
+++ b/src/utils/stateUpdateUtils.tsx
@@ -1,15 +1,14 @@
 import _ from 'lodash';
 import httpClient from '../httpClient'
-import { AggregationFactor, Filters, FilterType } from '../types'
+import { Filters, FilterType } from '../types'
 
 export const updateFilters = async (
   dispatch: any,
   filters: Filters,
   filterType: FilterType,
-  filterValue: any[],
+  filterValue: any,
   exploreIsOpen: Boolean,
-  page: string,
-  aggregationFactor: AggregationFactor) => {
+  page: string) => {
 
   dispatch({
     type: "CHANGE_LOADING",
@@ -29,7 +28,7 @@ export const updateFilters = async (
   });
 
   const updatedFilters: Filters = Object.assign({}, filters);
-  updatedFilters[filterType] = new Set(filterValue);
+  updatedFilters[filterType] = filterValue;
 
   const api = new httpClient()
   // Update current records when called

--- a/src/utils/stateUpdateUtils.tsx
+++ b/src/utils/stateUpdateUtils.tsx
@@ -7,7 +7,6 @@ export const updateFilters = async (
   filters: Filters,
   filterType: FilterType,
   filterValue: any,
-  exploreIsOpen: Boolean,
   page: string) => {
 
   dispatch({
@@ -35,7 +34,7 @@ export const updateFilters = async (
   const [records,
     estimateGradePrevalences] = await
       Promise.all([
-        api.getAirtableRecords(updatedFilters, exploreIsOpen),
+        api.getAirtableRecords(updatedFilters, true),
         api.getEstimateGrades(updatedFilters)
       ]);
  
@@ -57,7 +56,7 @@ export const updateFilters = async (
   })
 }
 
-export const initializeData = async (dispatch: any, filters: Filters, exploreIsOpen: Boolean, page: string) => {
+export const initializeData = async (dispatch: any, filters: Filters, page: string) => {
 
   const api = new httpClient()
 
@@ -71,7 +70,7 @@ export const initializeData = async (dispatch: any, filters: Filters, exploreIsO
   
   const [records,
     estimateGradePrevalences] = await Promise
-      .all([api.getAirtableRecords(filters, exploreIsOpen),
+      .all([api.getAirtableRecords(filters, true),
       api.getEstimateGrades(filters)]);
 
   dispatch({

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -438,6 +438,7 @@
     "Male": "Male",
     "Unspecified": "Unspecified"
   },
+  "ShowUnityStudies": "Show WHO Unity-aligned studies",
   "Source": "Source",
   "SourceType": "Source Type",
   "SourceTypeOptions": {
@@ -469,8 +470,17 @@
   },
   "StudyInformation": "Study Information",
   "StudyInformationTooltip": {
-    "FirstParagraph": "Filter on study details, including source type (publication, preprint, news, or report) and study status (ongoing, completed).",
-    "SecondParagraph": "Risk of bias: Reflects the extent to which the true prevalence may be different from the estimated prevalence. Estimated by SeroTracker reviewers based on the Joanna Briggs Institute critical appraisal tool for prevalence estimates."
+    "FirstParagraph": "Filter on study details, including source type (publication, preprint, news, or report), study status (ongoing, completed), and alignment with the WHO Unity protocol.",
+    "SecondParagraph": {
+      "PartOne": "Risk of bias: ",
+      "PartTwo": "Reflects the extent to which the true prevalence may be different from the estimated prevalence. Estimated by SeroTracker reviewers based on the Joanna Briggs Institute critical appraisal tool for prevalence estimates."
+    },
+    "ThirdParagraph": {
+      "PartOne": "WHO Unity protocol: ",
+      "PartTwo": "The WHO developed several standardized generic protocols for robust investigations for COVID-19: ",
+      "PartThree": "the Unity studies. ",
+      "PartFour": "SeroTracker is collaborating with the WHO to support and visualize studies aligned with the population-based seroepidemiological Unity protocol."
+    }
   },
   "StudyName": "Study name",
   "StudyPins": "Show Study Pins",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -438,7 +438,8 @@
     "Male": "Male",
     "Unspecified": "Unspecified"
   },
-  "ShowUnityStudies": "Show WHO Unity-aligned studies",
+  "UnityStudiesOnly": "WHO Unity only",
+  "UnityStudiesOnlyLong": "Show WHO Unity-aligned studies only",
   "Source": "Source",
   "SourceType": "Source Type",
   "SourceTypeOptions": {

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -472,13 +472,13 @@
   "StudyInformationTooltip": {
     "FirstParagraph": "Filter on study details, including source type (publication, preprint, news, or report), study status (ongoing, completed), and alignment with the WHO Unity protocol.",
     "SecondParagraph": {
-      "PartOne": "Risk of bias: ",
+      "PartOne": "Risk of bias:",
       "PartTwo": "Reflects the extent to which the true prevalence may be different from the estimated prevalence. Estimated by SeroTracker reviewers based on the Joanna Briggs Institute critical appraisal tool for prevalence estimates."
     },
     "ThirdParagraph": {
-      "PartOne": "WHO Unity protocol: ",
-      "PartTwo": "The WHO developed several standardized generic protocols for robust investigations for COVID-19: ",
-      "PartThree": "the Unity studies. ",
+      "PartOne": "WHO Unity protocol:",
+      "PartTwo": "The WHO developed several standardized generic protocols for robust investigations for COVID-19:",
+      "PartThree": "the Unity studies.",
       "PartFour": "SeroTracker is collaborating with the WHO to support and visualize studies aligned with the population-based seroepidemiological Unity protocol."
     }
   },

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -442,7 +442,8 @@
     "Male": "Homme",
     "Unspecified": "Non précisé"
   },
-  "ShowUnityStudies": "Montrer les études Unité-aligné",
+  "UnityStudiesOnly": "L'OMS-UNITY seulement",
+  "UnityStudiesOnlyLong": "Afficher seulement des études alignées avec l'OMS-UNITY",
   "Source": "Source",
   "SourceType": "Type de source",
   "SourceTypeOptions": {

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -476,14 +476,14 @@
   "StudyInformationTooltip": {
     "FirstParagraph": "Trier selon les détails d'étude, y compris le type de source (publication, préimpression, actualité ou rapport), l'état de l'étude (en cours, complétée), et l'alignement avec le protocole Unité.",
     "SecondParagraph": {
-      "PartOne": "Risque de partialité: ",
+      "PartOne": "Risque de partialité:",
       "PartTwo": "Reflète la mesure dans laquelle la prévalence réelle peut être différente de la prévalence estimée par les examinateurs de SeroTracker en fonction de l’outil d’evaluation critique de l’Institut Joanna Briggs."
     },
     "ThirdParagraph": {
-      "PartOne": "OMS protocole Unité: ",
-      "PartTwo": "L'OMS a developpé plusieurs protocoles standardisés pour les enquêtes de COVID-19: ",
-      "PartThree": "Les études Unité. ",
-      "PartFour": "SéroTracker travaille avec l'OMS pour soutenir et visualiser les études séro-épidémiologique en population aligné avec le protocole Unité.."
+      "PartOne": "Le protocole Unité de l’OMS:",
+      "PartTwo": "L’OMS a developpé plusieurs protocoles standardisés pour les enquêtes sur la COVID-19:",
+      "PartThree": "Les études Unité.",
+      "PartFour": "SéroTracker travaille avec l’OMS pour soutenir et visualiser les études séro-épidémiologique sur les populations alignées avec le protocole Unité."
     }
   },
   "StudySize": "Taille de l'étude",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -442,6 +442,7 @@
     "Male": "Homme",
     "Unspecified": "Non précisé"
   },
+  "ShowUnityStudies": "Montrer les études Unité-aligné",
   "Source": "Source",
   "SourceType": "Type de source",
   "SourceTypeOptions": {
@@ -473,8 +474,17 @@
   },
   "StudyInformation": "Informations sur l'étude",
   "StudyInformationTooltip": {
-    "FirstParagraph": "Trier selon les détails d'étude, y compris le type de source (publication, préimpression, actualité ou rapport) et l'état de l'étude (en cours, complétée).",
-    "SecondParagraph": "Risque de partialité: Reflète la mesure dans laquelle la prévalence réelle peut être différente de la prévalence estimée par les examinateurs de SeroTracker en fonction de l’outil d’evaluation critique de l’Institut Joanna Briggs"
+    "FirstParagraph": "Trier selon les détails d'étude, y compris le type de source (publication, préimpression, actualité ou rapport), l'état de l'étude (en cours, complétée), et l'alignement avec le protocole Unité.",
+    "SecondParagraph": {
+      "PartOne": "Risque de partialité: ",
+      "PartTwo": "Reflète la mesure dans laquelle la prévalence réelle peut être différente de la prévalence estimée par les examinateurs de SeroTracker en fonction de l’outil d’evaluation critique de l’Institut Joanna Briggs."
+    },
+    "ThirdParagraph": {
+      "PartOne": "OMS protocole Unité: ",
+      "PartTwo": "L'OMS a developpé plusieurs protocoles standardisés pour les enquêtes de COVID-19: ",
+      "PartThree": "Les études Unité. ",
+      "PartFour": "SéroTracker travaille avec l'OMS pour soutenir et visualiser les études séro-épidémiologique en population aligné avec le protocole Unité.."
+    }
   },
   "StudySize": "Taille de l'étude",
   "StudyStatus": "État de l'étude",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Adds unity studies checkbox and /Unity view (same as explore but with checkbox checked off by default)
- Changes filters and filter options data models to use arrays instead of sets (sets were an artifact from when we were doing filtering logic on the frontend)
- Removes some unnecessary code (dataPageState, some types that were not being used, API call that's not being used, unnecessary dispatches)

## Please link the Airtable ticket associated with this PR.

https://airtable.com/tbli2lWQHAqBa6ZcI/viwWvxb27XGuziw4c/recGnymO05NXQZDqX?blocks=bipIkdtYHmboUfJut

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

![image](https://user-images.githubusercontent.com/21212898/121589228-d492c300-ca04-11eb-9789-bfece8cd9db2.png)
![image](https://user-images.githubusercontent.com/21212898/121589293-e6746600-ca04-11eb-9ae4-974d256798c0.png)
![image](https://user-images.githubusercontent.com/21212898/121589371-fa1fcc80-ca04-11eb-909f-417ffd658bad.png)
![image](https://user-images.githubusercontent.com/21212898/121746081-50f3d780-cad3-11eb-94ce-76014647d1a6.png)



## Describe the steps you took to test the feature/bugfix introduced by this PR.

Smoke test

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

Yes, but PR has been merged

## Does this PR require any French translations? Have they been included?

Yes, will include them all once we figure out exactly what text we want to show
