### PR TITLE
Bug fix - all seroprevalence estimates showing as NULL on study modal

### DIFF
--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -40,7 +40,7 @@ export default function StudyPopup(record: AirtableRecord) {
             {Translate("BestSeroprevalenceEstimate")}
         </div>
         <div className="popup-text">
-            {record.seroprevalence ? `${(record.seroprevalence * 100).toFixed(1)}%` : "N/A"}
+            {record.serum_pos_prevalence ? `${(record.serum_pos_prevalence * 100).toFixed(1)}%` : "N/A"}
         </div>
         <div className="popup-heading">
             {Translate("N")}

--- a/src/components/shared/references/StudiesTable.tsx
+++ b/src/components/shared/references/StudiesTable.tsx
@@ -163,7 +163,7 @@ export default function StudiesTable(props: StudiesTableProps) {
                                 country, state, city,
                                 denominator,
                                 sex, age, population_group,
-                                seroprevalence,
+                                serum_pos_prevalence,
                                 sampling_end_date,
                                 overall_risk_of_bias: risk_of_bias,
                             } = record;
@@ -176,7 +176,7 @@ export default function StudiesTable(props: StudiesTableProps) {
                                     <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-2"}`}>{getGeography(city, state, country)}</Table.Cell>
                                     <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-2"}`}>{getPopulation(sex, age, population_group)}</Table.Cell>
                                     <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-1"}`}>{denominator ? denominator : "Not Reported"}</Table.Cell>
-                                    <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-1"}`}>{seroprevalence ? `${(seroprevalence * 100).toFixed(2)}%` : "Not Reported"}</Table.Cell>
+                                    <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-1"}`}>{serum_pos_prevalence ? `${(serum_pos_prevalence * 100).toFixed(2)}%` : "Not Reported"}</Table.Cell>
                                     <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-1"}`}>{risk_of_bias ? risk_of_bias : "Not Reported"}</Table.Cell>
                                     <Table.Cell className={`flex p-1 ${props.smallView ? "col-6" : "col-sm-12 col-lg-2"}`}>{getPossibleNullDateString(sampling_end_date)}</Table.Cell>
                                     <div className={hoverKey === index ? "hover" : "no-hover"}><StudyDetailsModal record={record} /></div>

--- a/src/components/shared/references/StudyDetailsModal.tsx
+++ b/src/components/shared/references/StudyDetailsModal.tsx
@@ -61,7 +61,7 @@ export default function StudyDetailsModal(props: StudyDetailsModalProps) {
     source_name, first_author, lead_organization, publish_date, publisher, url,
     summary, study_type,
     population_group, age, city, state, country, sex,
-    seroprevalence, overall_risk_of_bias: risk_of_bias, denominator,
+    serum_pos_prevalence, overall_risk_of_bias: risk_of_bias, denominator,
     sampling_method, sampling_end_date, sampling_start_date,
     test_type, sensitivity, specificity, isotypes_reported, test_manufacturer
   } = props.record
@@ -147,7 +147,7 @@ export default function StudyDetailsModal(props: StudyDetailsModalProps) {
               <div className="col-12 p-0 section-title">{Translate('Prevalence').toUpperCase()}</div>
               <div className="col-12 px-2 py-1 flex section-container modal-text-container">
                 <div className="col-12 p-0 secondary-text">
-                  <span className="secondary-title">{Translate('Estimate')}: </span>{seroprevalence ? (seroprevalence * 100).toFixed(2) : "Not Reported"}%
+                  <span className="secondary-title">{Translate('Estimate')}: </span>{serum_pos_prevalence ? (serum_pos_prevalence * 100).toFixed(2) : "Not Reported"}%
                 </div>
                 <div className="col-12 p-0 secondary-text">
                   <span className="secondary-title">{Translate('StudySize')}: </span>{getPossibleNullString(denominator)}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@ export type AirtableRecord = {
   sex: string | null;
   age: string | null;
   denominator: number | null;
-  seroprevalence: number | null;
+  serum_pos_prevalence: number | null;
   publish_date: string[] | string | null;
   publisher: string | null;
   overall_risk_of_bias: string | null;


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Seroprevalence field was showing as N/A for all study modals
- This was because the backend field is called serum_pos_prevalence but the frontend was calling record.seroprevalence

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Looked at study modals with and without different filters

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?
