### PR TITLE
Add airtable filter ordering for population_group

### DIFF
--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -17,6 +17,11 @@ interface FilterProps {
   page: string
 }
 
+interface PopulationGroupFilterOption {
+  english: string,
+  french: string
+}
+
 export default function Filters({ page }: FilterProps) {
   const [state, dispatch] = useContext(AppContext);
   const pageState = state[page as keyof State] as PageState;
@@ -39,12 +44,15 @@ export default function Filters({ page }: FilterProps) {
         });
         break;
       default:
-        options.forEach((o: string | string[]) => {
+        options.forEach((o: string | PopulationGroupFilterOption) => {
+          // This code block will be deprecated once as this becomes the standardized filter option logic
           if (filter_type === "population_group") {
+            o = o as PopulationGroupFilterOption;
+            const optionString = state.language === LanguageType.english ? o.english : o.french;
             formatted_options.push({
-              key: state.language === LanguageType.english ? o[0] : o[1],
-              text: state.language === LanguageType.english ? o[0] : o[1],
-              value: state.language === LanguageType.english ? o[0] : o[1]
+              key: optionString,
+              text: optionString,
+              value: optionString
             })
           } else {
             const translatedString = Translate(jsonObjectString, [toPascalCase(o as string)]);

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -11,6 +11,7 @@ import SectionHeader from "./SectionHeader";
 import Datepicker from "./datepicker/Datepicker";
 import { Link } from "react-router-dom";
 import "./Filters.css";
+import { LanguageType } from "../../../types";
 
 interface FilterProps {
   page: string
@@ -38,15 +39,23 @@ export default function Filters({ page }: FilterProps) {
         });
         break;
       default:
-        options.forEach((o: string) => {
-          const translatedString = Translate(jsonObjectString, [toPascalCase(o)]);
-          const alternativeString = Translate(jsonObjectString, [o.replace(/ /g, '')]);
-          let text = !alternativeString && !translatedString ? o + "*" : (translatedString ? translatedString : alternativeString);
-          formatted_options.push({
-            key: o,
-            text: text,
-            value: o
-          })
+        options.forEach((o: string | string[]) => {
+          if (filter_type === "population_group") {
+            formatted_options.push({
+              key: state.language === LanguageType.english ? o[0] : o[1],
+              text: state.language === LanguageType.english ? o[0] : o[1],
+              value: state.language === LanguageType.english ? o[0] : o[1]
+            })
+          } else {
+            const translatedString = Translate(jsonObjectString, [toPascalCase(o as string)]);
+            const alternativeString = Translate(jsonObjectString, [(o as string).replace(/ /g, '')]);
+            let text = !alternativeString && !translatedString ? o + "*" : (translatedString ? translatedString : alternativeString);
+            formatted_options.push({
+              key: o as string,
+              text: text,
+              value: o as string
+            })
+          }
         });
     };
     return formatted_options;


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Updated filters to pull from updated filter options endpoint 

## Please link the Airtable ticket associated with this PR.
https://airtable.com/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/rec5XzyfWRX4GQ3N4?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
