### PR TITLE
Explore - Download button

### DIFF
--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -4,12 +4,22 @@ import Translate from "utils/translate/translateService";
 import TotalStats from "./TotalStats";
 import HealthAgencyLogo from 'assets/images/public-health-agency.png';
 import UcalgaryLogo from 'assets/images/University-Of-Calgary-Logo.png';
+import { sendAnalyticsEvent } from "../../../utils/analyticsUtils";
 import WhoLogo from "components/shared/WhoLogo"
+import { Button } from "semantic-ui-react";
 import "../sidebar.css";
 
 interface SideBarProps {
   page: string
 }
+
+const clickLink = (link: string) => {
+  sendAnalyticsEvent({
+    category: "Data Link Click",
+    action: "click",
+    label: link,
+  });
+};
 
 export default function LeftSidebar({ page }: SideBarProps) {
 
@@ -21,9 +31,18 @@ export default function LeftSidebar({ page }: SideBarProps) {
       <p>
         {Translate('ExploreBlurb', ['FirstParagraph'])}
       </p>
-      <p>
-        {Translate('ExploreBlurb', ['SecondParagraph'])}
-      </p>
+      <div className="d-flex justify-content-center">
+        <Button color="blue" size="large" className="mx-auto">
+          <a
+            onClick={() => clickLink("DownloadCsv")}
+            target="_blank"
+            rel="noreferrer"
+            href={"https://docs.google.com/forms/d/e/1FAIpQLSdGd_wlq8YSyVPs2AOi1VfvxuLzxA8Ye5I3HkQwW_9yrumsCg/viewform"}
+          >
+            <p className="button-text"> {Translate("DownloadCsv")}</p>
+          </a>
+        </Button>
+      </div>
     </div>
   )
 


### PR DESCRIPTION
Added download button to explore page, removed unneeded descriptive text as per Jordano's request

![image](https://user-images.githubusercontent.com/22464147/127756662-35769079-7700-4d9e-9f21-521309b991b0.png)

