### PR TITLE
Added NYT and Economist articles

### DIFF
--- a/src/components/pages/Publications/PublicationsConstants.ts
+++ b/src/components/pages/Publications/PublicationsConstants.ts
@@ -158,6 +158,22 @@ const listOfMediaPublicationsProps: PublicationsCardProps[] = [
         url: "https://www.journaldequebec.com/2021/06/25/la-population-mondiale-toujours-vulnerable-a-la-covid-19",
     },
     {
+        day: "25",
+        month: "May",
+        year: "2021",
+        titleKey1: 'IndustryMediaTitles',
+        titleKey2: ['NYTIndia'],
+        url: "https://www.nytimes.com/interactive/2021/05/25/world/asia/india-covid-death-estimates.html",
+    },
+    {
+        day: "13",
+        month: "May",
+        year: "2021",
+        titleKey1: 'IndustryMediaTitles',
+        titleKey2: ['EconomistDeathToll'],
+        url: "https://www.economist.com/graphic-detail/2021/05/13/how-we-estimated-the-true-death-toll-of-the-pandemic",
+    },
+    {
         day: "23",
         month: "January",
         year: "2021",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -261,7 +261,9 @@
     "JouleInnovation": "SeroTracker: Joule innovation grant recipient",
     "WhenEnd": "When will the COVID-19 pandemic end?",
     "JouleAnnounce": "Joule announces 2020 Innovation grant recipients",
-    "StillVulnerable": "The world's population is still vulnerable to COVID-19"
+    "StillVulnerable": "The world's population is still vulnerable to COVID-19",
+    "NYTIndia": "Just how big could India’s true Covid toll be?",
+    "EconomistDeathToll": "How we estimated the true death toll of the pandemic"
   },
   "IndustryReportTitles": {
     "AugustReport": "August Report - COVID-19 Screening & Testing in Canada’s Private Sector",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -257,7 +257,9 @@
     "JouleInnovation": "SeroTracker : bénéficiaire de la bourse «Innovation» de Joule",
     "WhenEnd": "Quand la pandémie de COVID-19 prendra-t-elle fin?",
     "JouleAnnounce": "Joule annonce les lauréats des bourses «Innovation» 2020",
-    "StillVulnerable": "La population mondiale toujours vulnérable à la COVID-19"
+    "StillVulnerable": "La population mondiale toujours vulnérable à la COVID-19",
+    "NYTIndia": "Quelle pourrait être la vraie ampleur de la propagation de Covid en Inde?",
+    "EconomistDeathToll": "Comment avons-nous estimé le véritable nombre de morts de la pandémie?"
   },
   "IndustryReportTitles": {
     "AugustReport": "Rapport d'Août - Covid-19 dépistage et d'essais dans le secteur privé du Canada",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Adds NYT and Economist articles

## Please link the Airtable ticket associated with this PR.

N/A

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Local test

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

N/A

## Does this PR require any French translations? Have they been included?

![image](https://user-images.githubusercontent.com/21212898/128234604-d844a43b-cb38-492a-9a50-de79b2640623.png)

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
