### PR TITLE
fixed a spacing issue in the publications page

### DIFF
--- a/src/components/pages/Publications/Publications.tsx
+++ b/src/components/pages/Publications/Publications.tsx
@@ -11,7 +11,7 @@ export default function Publications() {
   const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth })
 
   return (
-    <div className="col-12 page pb-6">
+    <div className="col-12 page pb-4">
       <div className={isMobileDeviceOrTablet ? "pb-2 policy-container" : "policy-container static-content"}>
         <h1 className="col-12 p-0 fit">
           {Translate('Publications')}
@@ -66,7 +66,7 @@ export type PublicationsType = 'articles' | 'reports' | 'media';
 
 const getCarouselOfPublicationsCards = (type: PublicationsType) => {
   return (
-    <div className="slider-container">
+    <div className="publications-slider-container">
       <Slider 
         {...sliderSettings}
       >

--- a/src/components/pages/Publications/styles.scss
+++ b/src/components/pages/Publications/styles.scss
@@ -71,6 +71,6 @@
 .slick-next:before { content: "›"; }
 
 // https://github.com/akiran/react-slick/issues/1571
-.slider-container {
+.publications-slider-container {
   max-width: 80vw;
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
The spacing on the publications page was broken. 2 line fix for that

## Please link the Airtable ticket associated with this PR.

NA

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

![image](https://user-images.githubusercontent.com/29795835/129267160-5047d75e-0df9-428b-88c5-11e0f520f226.png)

back to normal:
![image](https://user-images.githubusercontent.com/29795835/129267194-a41b2e3a-5162-47a3-82fc-839e21bc3bb9.png)


## Describe the steps you took to test the feature/bugfix introduced by this PR.

Visual test

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

no

## Does this PR require any French translations? Have they been included?

no

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
