### PR TITLE
Filter options UI bug fixes

### DIFF
--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -57,7 +57,7 @@ export default function Filters({ page }: FilterProps) {
           } else {
             const translatedString = Translate(jsonObjectString, [toPascalCase(o as string)]);
             const alternativeString = Translate(jsonObjectString, [(o as string).replace(/ /g, '')]);
-            let text = !alternativeString && !translatedString ? o + "*" : (translatedString ? translatedString : alternativeString);
+            let text = !alternativeString && !translatedString ? o as string : (translatedString ? translatedString : alternativeString);
             formatted_options.push({
               key: o as string,
               text: text,


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

## Please link the Airtable ticket associated with this PR.
[Airtable ticket](https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/reccx2r25p2FPLl1R?blocks=hide)

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
