### PR TITLE
Bug fix for vaccination policy high flag

### DIFF
--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -52,7 +52,7 @@ export default function StudyPopup(record: AirtableRecord) {
             {Translate("VaccineRolloutStatus")}
         </div>
         <div className="popup-text">
-            {(record.vaccination_policy == 0) ? Translate("VaccinationPolicyLow") : (record.vaccination_policy == 1 || record.vaccination_policy == 2 || record.vaccination_policy == 3) ? Translate("VaccinationPolicyMed") : Translate("VaccinationPolicy")}
+            {(record.vaccination_policy == 0) ? Translate("VaccinationPolicyLow") : (record.vaccination_policy == 1 || record.vaccination_policy == 2 || record.vaccination_policy == 3) ? Translate("VaccinationPolicyMed") : Translate("VaccinationPolicyHigh")}
         </div>
         <div className="popup-heading">
             {Translate("RiskOfBias")}


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
![image](https://user-images.githubusercontent.com/37022160/134072243-3692b439-f76a-4272-81d1-706f775ca473.png)
- when the vaccination policy is high i.e. vaccinations available to broader population it just says VaccinationPolicy
- variable name was wrong, it should be VaccinationPolicyHigh instead

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
