### PR TITLE
QA fixes

### DIFF
--- a/src/components/pages/Data.tsx
+++ b/src/components/pages/Data.tsx
@@ -31,7 +31,7 @@ function DataButtons() {
     },
     {
       label: "DataDictionary",
-      link: "https://docs.google.com/spreadsheets/d/1KQbp5T9Cq_HnNpmBTWY1iKs6Etu1-qJcnhdJ5eyw7N8/edit?usp=sharing",
+      link: "https://airtable.com/shr9XzggGpYFqMdJF/tblIdx2b6ZOLevdJr",
       id: PAGE_HASHES.Data.DataDictionary,
     },
     {

--- a/src/components/pages/Publications/PublicationsConstants.ts
+++ b/src/components/pages/Publications/PublicationsConstants.ts
@@ -360,7 +360,7 @@ const listOfBiblioDigests: PublicationProps[] = [
     {
         titleKey1: 'BiblioDigestTitles',
         titleKey2: ['LateOctober'],
-        url: "https://drive.google.com/file/d/1jVvi9fEO8VM_LQ2vCfgF0oYFRd1tqwYw/view?usp=sharing"
+        url: "https://drive.google.com/file/d/11JHvvKtR9_s2HQHeHmp6j-hx8Y1sIF-O/view?usp=sharing"
     },
     {
         titleKey1: 'BiblioDigestTitles',


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Fixes data dictionary and Late October report links.

## Please link the Airtable ticket associated with this PR.
- [Fix Data Dictionary link on Data page ](https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/recpbJfQDkeQSIsQE?blocks=hide)
- [Fix Late October report link](https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/recJuzrOOnPVr1lYC?blocks=hide)

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
