### PR TITLE
Citf bug

### DIFF
--- a/src/components/partnerships/PartnershipsMap.tsx
+++ b/src/components/partnerships/PartnershipsMap.tsx
@@ -20,7 +20,7 @@ const desktopMap = (
 ) => {
   return (
     <>
-      <div className="col-10">
+      <div className="col-9 h-100">
         <MapboxMap
           mapConfig={partnershipconfig.mapboxMapOptions}
           countriesConfig={{
@@ -32,14 +32,14 @@ const desktopMap = (
           }}
         />
       </div>
-      <div className="col-2">
+      <div className="col-3 h-100">
         <Legend hideLayers />
-        <div className="mt-5">{Translate("PartnershipsView", ["MapNote1"])}</div>
-        <div className="mt-3">
-          {Translate("PartnershipsView", ["MapNote2"], {
-            WEBSITE: "ourworldindata.org",
-          })}
-        </div>
+          <div className="mt-1">{Translate("PartnershipsView", ["MapNote1"])}</div>
+          <div className="mt-1">
+              {Translate("PartnershipsView", ["MapNote2"], {
+                  WEBSITE: "ourworldindata.org",
+              })}
+          </div>
       </div>
     </>
   );
@@ -85,11 +85,11 @@ export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapPr
   }
 
   const Map = isMobileDeviceOrTablet ? mobileMap(partnershipconfig, estimateGradePrevalence, records): desktopMap(partnershipconfig, estimateGradePrevalence, records)
-  const mapHeight = isMobileDeviceOrTablet ? "50vw" : "100%"
+  const mapHeight = isMobileDeviceOrTablet ? "50vw" : "70vh"
   return (
     <div style={{ height: mapHeight }} className="row">
     <Loader indeterminate active={state.explore.isLoading} />
       {Map}
     </div>
-  );;
+  );
 }

--- a/src/components/partnerships/PartnershipsMap.tsx
+++ b/src/components/partnerships/PartnershipsMap.tsx
@@ -85,7 +85,7 @@ export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapPr
   }
 
   const Map = isMobileDeviceOrTablet ? mobileMap(partnershipconfig, estimateGradePrevalence, records): desktopMap(partnershipconfig, estimateGradePrevalence, records)
-  const mapHeight = isMobileDeviceOrTablet ? "50vw" : "70vh"
+  const mapHeight = isMobileDeviceOrTablet ? "50vw" : "100%"
   return (
     <div style={{ height: mapHeight }} className="row">
     <Loader indeterminate active={state.explore.isLoading} />


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
The mapbox and tableau fivs were overlapping. I fixed this overlap
## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/reckgjJuEe0BePStc?blocks=hide
## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).
after:
![image](https://user-images.githubusercontent.com/29795835/143953110-4275e54e-18df-499e-9a56-7d3e514aea1d.png)
before:
![image](https://user-images.githubusercontent.com/29795835/143953180-6f10ed2d-38dd-4365-be75-8e765722a3c0.png)

## Describe the steps you took to test the feature/bugfix introduced by this PR.
visual test
## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
