### PR TITLE
About page links

### DIFF
--- a/src/components/pages/About.tsx
+++ b/src/components/pages/About.tsx
@@ -81,34 +81,35 @@ export default function About() {
         <Sponsers />
         <p>
           {Translate("AboutPage", ["AboutSection", "SupportedBy"])}
-          <a onClick={() => selectLink("Public Health Agency")} href="https://www.canada.ca/en/public-health.html">
+          <a target="_blank" rel="noreferrer noopener" onClick={() => selectLink("Public Health Agency")} href="https://www.canada.ca/en/public-health.html">
             {Translate("AboutPage", ["AboutSection", "PublicHealthAgency"], null, [true, true])}
           </a>
           {Translate("AboutPage", ["AboutSection", "ThroughThe"])}
-          <a onClick={() => selectLink("ITF Website")} href="https://www.covid19immunitytaskforce.ca/">
+          <a target="_blank" rel="noreferrer noopener" onClick={() => selectLink("ITF Website")} href="https://www.covid19immunitytaskforce.ca/">
             {Translate("AboutPage", ["AboutSection", "Covid19ImmunityTaskForce"], null, [true, true])}
           </a>
           {Translate("AboutPage", ["AboutSection", "HostedAt"])}
           <a
             onClick={() => selectLink("Centre for Health Informatics")}
             href="https://cumming.ucalgary.ca/centres/centre-health-informatics"
+            target="_blank" rel="noreferrer noopener"
           >
             {Translate("AboutPage", ["AboutSection", "HealthInformatics"], null, [true, true])}
           </a>
         </p>
         <p>
           {Translate("AboutPage", ["AboutSection", "WHO1"])}
-          <a onClick={() => selectLink("WorldHealthOrganization")} href="https://www.who.int/">
+          <a onClick={() => selectLink("WorldHealthOrganization")} href="https://www.who.int/" target="_blank" rel="noreferrer noopener">
             {Translate("AboutPage", ["AboutSection", "WorldHealthOrganization"], null, [true, true])}
           </a>
           {Translate("AboutPage", ["AboutSection", "WHO2"])}
-          <a onClick={() => selectLink("UnityStudies")} href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/early-investigations">
+          <a target="_blank" rel="noreferrer noopener" onClick={() => selectLink("UnityStudies")} href="https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/early-investigations">
             {Translate("AboutPage", ["AboutSection", "UnityStudies"], null, [true, false])}
           </a>
           {Translate("AboutPage", ["AboutSection", "WHO3"], null, [true, true])}
         </p>
         <p>
-          <a onClick={() => selectLink("Mapbox")} href="https://www.mapbox.com/">
+          <a onClick={() => selectLink("Mapbox")} href="https://www.mapbox.com/" target="_blank" rel="noreferrer noopener">
             Mapbox
           </a>{" "}
           {Translate("AboutPage", ["Mapbox"])}
@@ -117,13 +118,13 @@ export default function About() {
         <div>
           <p>
             {Translate("AboutPage", ["ContactSection", "BulletPointOne", "PartOne"], null, [true, true])}
-            <a href="mailto:rahul.arora@balliol.ox.ac.uk">rahul.arora@balliol.ox.ac.uk</a>
+            <a target="_blank" rel="noreferrer noopener" href="mailto:rahul.arora@balliol.ox.ac.uk">rahul.arora@balliol.ox.ac.uk</a>
             {Translate("AboutPage", ["ContactSection", "BulletPointOne", "PartTwo"], null, [true, true])}
-            <a href="mailto:tingting.yan@mail.utoronto.ca">tingting.yan@mail.utoronto.ca</a>.
+            <a target="_blank" rel="noreferrer noopener" href="mailto:tingting.yan@mail.utoronto.ca">tingting.yan@mail.utoronto.ca</a>.
             {Translate("AboutPage", ["ContactSection", "BulletPointOne", "PartThree"], null, [true, true])}
-            <a href="mailto:media@covid19immunitytaskforce.ca">media@covid19immunitytaskforce.ca</a>
+            <a target="_blank" rel="noreferrer noopener" href="mailto:media@covid19immunitytaskforce.ca">media@covid19immunitytaskforce.ca</a>
             {Translate("AboutPage", ["ContactSection", "BulletPointOne", "PartFour"], null, [true, true])}
-            <a href="mailto:kelly.johnston2@ucalgary.ca">kelly.johnston2@ucalgary.ca</a>.
+            <a target="_blank" rel="noreferrer noopener" href="mailto:kelly.johnston2@ucalgary.ca">kelly.johnston2@ucalgary.ca</a>.
           </p>
           <p>
             {Translate("AboutPage", ["ContactSection", "BulletPointFive", "PartOne"])}

--- a/src/components/pages/Publications/PublicationsConstants.ts
+++ b/src/components/pages/Publications/PublicationsConstants.ts
@@ -359,6 +359,11 @@ const listOfMediaPublicationsProps: PublicationProps[] = [
 const listOfBiblioDigests: PublicationProps[] = [
     {
         titleKey1: 'BiblioDigestTitles',
+        titleKey2: ['November'],
+        url: "https://drive.google.com/file/d/1kwMjD6w2onk9lh-sCOgAcEBH-I1DrW7_/view"
+    },
+    {
+        titleKey1: 'BiblioDigestTitles',
         titleKey2: ['LateOctober'],
         url: "https://drive.google.com/file/d/11JHvvKtR9_s2HQHeHmp6j-hx8Y1sIF-O/view?usp=sharing"
     },

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -272,6 +272,7 @@
     "PlosOnePub": "Global seroprevalence of SARS-CoV-2 antibodies: a systematic review and meta-analysis"
   },
   "BiblioDigestTitles": {
+    "November": "November Literature Update Report",
     "LateOctober": "Late October Literature Update Report",
     "October": "October Literature Update Report",
     "September": "September Literature Update Report",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -269,6 +269,7 @@
     "PlosOnePub": "Séroprévalence globale des anticorps contre la SRAS-CoV-2: une revue systématique et méta-analyse"
   },
   "BiblioDigestTitles": {
+    "November": "Le bulletin de mise à jour de la littérature de fin novembre",
     "LateOctober": "Le bulletin de mise à jour de la littérature de fin octobre",
     "October": "Le bulletin de mise à jour de la littérature de octobre",
     "September": "Le bulletin de mise à jour de la littérature de septembre",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Links on about pages were not opening in a new tab. 
Added in the november literature report
## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recFPLl9d5J04xF2m?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?
yes yes
## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
