### PR TITLE
Fix CITF map positioning and add loading state 

### DIFF
--- a/src/PartnershipsConfig.ts
+++ b/src/PartnershipsConfig.ts
@@ -11,8 +11,8 @@ const PartnershipsConfig: Partnership[] = [
             },
             mapboxMapOptions: {
                 bounds: [
-                    [-140.99, 41.67], // Southwest coordinates
-                    [-52.64, 83.23] // Northeast coordinates
+                    [-148, 39], // Southwest coordinates
+                    [-50, 75] // Northeast coordinates
                 ],
                 /*
                 maxBounds: [

--- a/src/components/partnerships/PartnershipsMap.tsx
+++ b/src/components/partnerships/PartnershipsMap.tsx
@@ -13,14 +13,70 @@ type PartnerShipsMapProps = {
   partnershipconfig?: Partnership;
 };
 
-const desktopMap = (
-  partnershipconfig: Partnership,
-  estimateGradePrevalence: EstimateGradePrevalence | undefined,
-  records: AirtableRecord[]
-) => {
-  return (
-    <>
-      <div className="col-9 h-100">
+export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapProps) {
+  const [state] = useContext(AppContext);
+  const [records, setRecords] = useState<AirtableRecord[]>([]);
+  const [estimateGradePrevalence, setEstimateGradePrevalence] = useState<EstimateGradePrevalence | undefined>();
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  useEffect(() => {
+    const api = new httpClient();
+    const getPartnershipsData = async () => {
+      setIsLoading(true);
+      const { records, estimateGradePrevalences } = await api.getCountryPartnershipData({country: [partnershipconfig?.routeName]});
+      setRecords(records);
+      setEstimateGradePrevalence(estimateGradePrevalences[0]);
+      setIsLoading(false);
+    }
+    getPartnershipsData();
+  }, [partnershipconfig, state.explore.estimateGradePrevalences])
+  const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth })
+
+  if (partnershipconfig === undefined) {
+    return <></>;
+  }
+
+  const desktopMap = (
+    partnershipconfig: Partnership,
+    estimateGradePrevalence: EstimateGradePrevalence | undefined,
+    records: AirtableRecord[]
+  ) => {
+    return (
+      <>
+        <div className="col-9 h-100">
+          <Loader indeterminate active={isLoading}/>
+          <MapboxMap
+            mapConfig={partnershipconfig.mapboxMapOptions}
+            countriesConfig={{
+              estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
+              countryFocus: partnershipconfig?.iso3,
+            }}
+            studyPinsConfig={{
+              records: records,
+            }}
+          />
+        </div>
+        <div className="col-3 h-100">
+          <Legend hideLayers />
+            <div className="mt-1">{Translate("PartnershipsView", ["MapNote1"])}</div>
+            <div className="mt-1">
+                {Translate("PartnershipsView", ["MapNote2"], {
+                    WEBSITE: "ourworldindata.org",
+                })}
+            </div>
+        </div>
+      </>
+    );
+  };
+  
+  // Note: Loading spinner doesn't work very well on mobile
+  // Not a priority to implement because mobile is deprecated anyways
+  const mobileMap = (
+    partnershipconfig: Partnership,
+    estimateGradePrevalence: EstimateGradePrevalence | undefined,
+    records: AirtableRecord[]
+  ) => {
+    return (
         <MapboxMap
           mapConfig={partnershipconfig.mapboxMapOptions}
           countriesConfig={{
@@ -31,64 +87,13 @@ const desktopMap = (
             records: records,
           }}
         />
-      </div>
-      <div className="col-3 h-100">
-        <Legend hideLayers />
-          <div className="mt-1">{Translate("PartnershipsView", ["MapNote1"])}</div>
-          <div className="mt-1">
-              {Translate("PartnershipsView", ["MapNote2"], {
-                  WEBSITE: "ourworldindata.org",
-              })}
-          </div>
-      </div>
-    </>
-  );
-};
-
-const mobileMap = (
-  partnershipconfig: Partnership,
-  estimateGradePrevalence: EstimateGradePrevalence | undefined,
-  records: AirtableRecord[]
-) => {
-  return (
-      <MapboxMap
-        mapConfig={partnershipconfig.mapboxMapOptions}
-        countriesConfig={{
-          estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
-          countryFocus: partnershipconfig?.iso3,
-        }}
-        studyPinsConfig={{
-          records: records,
-        }}
-      />
-  );
-};
-
-export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapProps) {
-  const [state] = useContext(AppContext);
-  const [records, setRecords] = useState<AirtableRecord[]>([]);
-  const [estimateGradePrevalence, setEstimateGradePrevalence] = useState<EstimateGradePrevalence | undefined>();
-
-  useEffect(() => {
-    const api = new httpClient();
-    const getPartnershipsData = async () => {
-      const { records, estimateGradePrevalences } = await api.getCountryPartnershipData({country: [partnershipconfig?.routeName]});
-      setRecords(records);
-      setEstimateGradePrevalence(estimateGradePrevalences[0]);
-    }
-    getPartnershipsData()
-  }, [partnershipconfig, state.explore.estimateGradePrevalences])
-  const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth })
-
-  if (partnershipconfig === undefined) {
-    return <></>;
-  }
+    );
+  };
 
   const Map = isMobileDeviceOrTablet ? mobileMap(partnershipconfig, estimateGradePrevalence, records): desktopMap(partnershipconfig, estimateGradePrevalence, records)
   const mapHeight = isMobileDeviceOrTablet ? "50vw" : "70vh"
   return (
     <div style={{ height: mapHeight }} className="row">
-    <Loader indeterminate active={state.explore.isLoading} />
       {Map}
     </div>
   );

--- a/src/components/partnerships/PartnershipsMap.tsx
+++ b/src/components/partnerships/PartnershipsMap.tsx
@@ -13,6 +13,61 @@ type PartnerShipsMapProps = {
   partnershipconfig?: Partnership;
 };
 
+// Not a priority to implement loader here because mobile is deprecated anyways
+const mobileMap = (
+  partnershipconfig: Partnership,
+  estimateGradePrevalence: EstimateGradePrevalence | undefined,
+  records: AirtableRecord[]
+) => {
+  return (
+      <MapboxMap
+        mapConfig={partnershipconfig.mapboxMapOptions}
+        countriesConfig={{
+          estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
+          countryFocus: partnershipconfig?.iso3,
+        }}
+        studyPinsConfig={{
+          records: records,
+        }}
+      />
+  );
+};
+
+
+const desktopMap = (
+  partnershipconfig: Partnership,
+  estimateGradePrevalence: EstimateGradePrevalence | undefined,
+  records: AirtableRecord[],
+  isLoading: boolean
+) => {
+  return (
+    <>
+      <div className="col-9 h-100">
+        <Loader indeterminate active={isLoading}/>
+        <MapboxMap
+          mapConfig={partnershipconfig.mapboxMapOptions}
+          countriesConfig={{
+            estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
+            countryFocus: partnershipconfig?.iso3,
+          }}
+          studyPinsConfig={{
+            records: records,
+          }}
+        />
+      </div>
+      <div className="col-3 h-100">
+        <Legend hideLayers />
+          <div className="mt-1">{Translate("PartnershipsView", ["MapNote1"])}</div>
+          <div className="mt-1">
+              {Translate("PartnershipsView", ["MapNote2"], {
+                  WEBSITE: "ourworldindata.org",
+              })}
+          </div>
+      </div>
+    </>
+  );
+};
+
 export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapProps) {
   const [state] = useContext(AppContext);
   const [records, setRecords] = useState<AirtableRecord[]>([]);
@@ -35,62 +90,10 @@ export default function PartnerShipsMap({ partnershipconfig }: PartnerShipsMapPr
   if (partnershipconfig === undefined) {
     return <></>;
   }
-
-  const desktopMap = (
-    partnershipconfig: Partnership,
-    estimateGradePrevalence: EstimateGradePrevalence | undefined,
-    records: AirtableRecord[]
-  ) => {
-    return (
-      <>
-        <div className="col-9 h-100">
-          <Loader indeterminate active={isLoading}/>
-          <MapboxMap
-            mapConfig={partnershipconfig.mapboxMapOptions}
-            countriesConfig={{
-              estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
-              countryFocus: partnershipconfig?.iso3,
-            }}
-            studyPinsConfig={{
-              records: records,
-            }}
-          />
-        </div>
-        <div className="col-3 h-100">
-          <Legend hideLayers />
-            <div className="mt-1">{Translate("PartnershipsView", ["MapNote1"])}</div>
-            <div className="mt-1">
-                {Translate("PartnershipsView", ["MapNote2"], {
-                    WEBSITE: "ourworldindata.org",
-                })}
-            </div>
-        </div>
-      </>
-    );
-  };
   
   // Note: Loading spinner doesn't work very well on mobile
-  // Not a priority to implement because mobile is deprecated anyways
-  const mobileMap = (
-    partnershipconfig: Partnership,
-    estimateGradePrevalence: EstimateGradePrevalence | undefined,
-    records: AirtableRecord[]
-  ) => {
-    return (
-        <MapboxMap
-          mapConfig={partnershipconfig.mapboxMapOptions}
-          countriesConfig={{
-            estimateGradePrevalences: estimateGradePrevalence ? [estimateGradePrevalence] : undefined,
-            countryFocus: partnershipconfig?.iso3,
-          }}
-          studyPinsConfig={{
-            records: records,
-          }}
-        />
-    );
-  };
 
-  const Map = isMobileDeviceOrTablet ? mobileMap(partnershipconfig, estimateGradePrevalence, records): desktopMap(partnershipconfig, estimateGradePrevalence, records)
+  const Map = isMobileDeviceOrTablet ? mobileMap(partnershipconfig, estimateGradePrevalence, records) : desktopMap(partnershipconfig, estimateGradePrevalence, records, isLoading)
   const mapHeight = isMobileDeviceOrTablet ? "50vw" : "70vh"
   return (
     <div style={{ height: mapHeight }} className="row">


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

Fixes CITF map positioning and adds loading state (only applicable on desktop)

## Please link the Airtable ticket associated with this PR.

https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw4trdGlGgVxhdcj/recemgwEfOz5D0wAX?blocks=bip9X54YrLFYz3ycP

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

Old CITF map positioning:
![image](https://user-images.githubusercontent.com/21212898/144756191-cb509fc0-3722-4b2c-8050-bd057219f221.png)

New CITF map positioning:
![image](https://user-images.githubusercontent.com/21212898/144756202-e8cbda03-8df4-4039-9062-c8d48daeafe7.png)


## Describe the steps you took to test the feature/bugfix introduced by this PR.

Tested locally against prod backend. Ensured no regressions on the CITF page. 

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

N/A

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
