### PR TITLE
Bug fix: Translate all filter options to French

### DIFF
--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -59,12 +59,9 @@
   "Age": "Âge",
   "AgeGroup": "Groupe d'âge",
   "AgeOptions": {
-    "Adults(18-64)": "Adultes (18-64)",
-    "All": "Tous",
-    "Children(0-12)": "Enfants (0-12)",
-    "Seniors(65+)": "Personnes âgées (65+)",
-    "Unspecified": "Non précisé",
-    "Youth(13-17)": "Jeunes (13-17)"
+    "Adults1864Years": "Adultes (18-64 ans)",
+    "ChildrenAndYouth017Years": "Enfants et jeunes (0-17 ans)",
+    "Seniors65Years": "Aînés (65 ans et plus)"
   },
   "AggregatedPrevalence": "Fréquence cumulative",
   "Aggregating": "agrégeant ",
@@ -362,6 +359,12 @@
   },
   "OurProtocol": "Notre protocole",
   "OverallRiskOfBias": "Risque général de partialité",
+  "OverallRiskOfBiasOptions": {
+    "Low": "Bas",
+    "Moderate": "Modérer",
+    "High": "Élevé",
+    "Unclear": "Pas clair"
+  },
   "Paper": "Article",
   "PaperText": "Vous trouverez notre premier manuscrit décrivant les enseignements des sérosondages jusqu'au 1er mai sur",
   "PaperTextTwo": "Pour plus d'informations sur notre tableau de bord, consultez",
@@ -467,14 +470,14 @@
   "Settings": "Paramètres",
   "Sex": "Sexe",
   "SexOptions": {
-    "All": "Tous",
     "Female": "Femme",
     "Male": "Homme",
-    "Unspecified": "Non précisé"
+    "Other": "Autre"
   },
   "Source": "Source",
   "SourceType": "Type de source",
   "SourceTypeOptions": {
+    "JournalArticlePeerReviewed": "Article de revue (évalué par les pairs)",
     "InstitutionalReport": "Rapport institutionnel",
     "NewsAndMedia": "Actualités et médias",
     "Preprint": "Préimpression",
@@ -535,18 +538,11 @@
   "TestsAdministered": "Tests d'anticorps administrés",
   "TestType": "Type de test",
   "TestTypeOptions": {
-    "ChemiluminescenceImmunoassay": "Immunodosage en chimiluminescence",
-    "ColloidalGold": "Or colloïdal",
-    "ElectroChemiluminescenceImmunoassay": "Immunodosage en électrochimiluminescence",
-    "ELISA": "ELISA",
-    "LFIA": "LFIA",
-    "LIPS": "LIPS",
-    "MicrosphereImmunoassay": "Immunodosage à microsphère",
-    "NeutralizationAssay": "Test de neutralisation",
-    "NotReported": "Non signalé",
-    "RapidImmunochromatographicTest": "Test immunochromatographique rapide",
-    "RDT": "RDT",
-    "SolidPhaseImmunochromatography": "Immunochromatographie en phase solide"
+    "Neutralization": "Neutralisation",
+    "Clia": "CLIA",
+    "Elisa": "ELISA",
+    "Lfia": "LFIA",
+    "Other": "Autre"
   },
   "TestUsed": "Test utilisé",
   "ThisForm": "Ce formulaire",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

This PR translates all filter options to French (there were some stragglers that were in still in English) as a result of QA.

## Please link the Airtable ticket associated with this PR.
[Bug fix: Translate all filter options to French](https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/recJTB5zdrGlcusR0?blocks=hide)

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).
Source type:
![image](https://user-images.githubusercontent.com/33983945/144779679-15766b1a-a816-4cf3-bd50-478c8e2808eb.png)

Overall risk of bias:
![image](https://user-images.githubusercontent.com/33983945/144779705-538dbd3c-f87e-464c-8b63-46aeaa3e5fa8.png)

Sex:
![image](https://user-images.githubusercontent.com/33983945/144779720-a0883b6a-a984-4ce4-890a-edd7b5513afc.png)

Age:
![image](https://user-images.githubusercontent.com/33983945/144779736-fbebef82-eea1-4f53-84f7-f1147070b533.png)

Test type:
![image](https://user-images.githubusercontent.com/33983945/144779764-4b89edef-14a6-479a-bc23-68b75a0258f1.png)

## Describe the steps you took to test the feature/bugfix introduced by this PR.
Manual check on local

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.
Nope!

## Does this PR require any French translations? Have they been included?
Whole PR is French translations!

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
