### PR TITLE
Footer - Link order fixes

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,27 +29,27 @@ export const PAGE_HASHES = {
         Map: "Map"
     },
     [PAGES.Analyze]: {
-        ByCountry: "ByCountry", 
-        ByPopulation: "ByPopulation", 
+        ByCountry: "ByCountry",
+        ByPopulation: "ByPopulation",
         AdditionalGraphs: "AdditionalGraphs"
-    }, 
+    },
     [PAGES.Data]: {
+        DataDictionary: "DataDictionary",
+        ChangeLog: "ChangeLog",
+        SubmitSource: "SubmitSource",
         DownloadData: "DownloadData",
         FAQ: "FAQ",
-        SubmitSource: "SubmitSource",
-        ChangeLog: "ChangeLog",
-        DataDictionary: "DataDictionary",
         References: "References"
     },
     [PAGES.Publications]: {
         ResearchArticles: "ResearchArticles",
         PrivateSectorReports: "PrivateSectorReports",
-        MediaMentions: "MediaMentions",
         BiblioDigests: "BiblioDigests",
-        MonthlyReports: "MonthlyReports"
+        MonthlyReports: "MonthlyReports",
+        MediaMentions: "MediaMentions",
     },
     [PAGES.About]: {
-        Team: "Team",
-        ContactUs: "ContactUs"
+        ContactUs: "ContactUs",
+        Team: "Team"
     }
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Fixes order of footer links to reflect order in actual pages

## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwKscR1ZvgkUxVtA/rec9vWcScRx7nWWoF?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).
Before:
![image](https://user-images.githubusercontent.com/22464147/145302051-36c11ce8-d8fd-4cfd-94d9-0948057339bb.png)
After:
![image](https://user-images.githubusercontent.com/22464147/145302247-78724709-6c84-468f-b6d3-7a5d262e69c4.png)

