### PR TITLE
Translate Study Modal Date & Pop Group

### DIFF
--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -84,7 +84,6 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
       let pinPopup: mapboxgl.Popup | undefined = undefined;
 
       map.on("click", "study-pins", function (e: mapboxgl.MapMouseEvent & mapboxgl.EventData) {
-
         if (pinPopup !== undefined)
         {
           pinPopup.remove()
@@ -94,8 +93,7 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
         api.getRecordDetails(source_id).then((record) => {
           if (record !== null) {
             // substitute population group with its translation
-            // TODO: refactor so that we no longer need filter options to be a set
-            const popGroupOptions = Array.from(state.allFilterOptions.population_group);
+            const popGroupOptions = state.allFilterOptions.population_group;
             const popGroupWithTranslations = popGroupOptions.find(x => x.english === record.population_group)
             // TODO: refactor backend so that popGroupOptions keys directly map to languages on the frontend
             const languageTypeMapping = {

--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -92,26 +92,12 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
 
         api.getRecordDetails(source_id).then((record) => {
           if (record !== null) {
-            // substitute population group with its translation
-            const popGroupOptions = state.allFilterOptions.population_group;
-            const popGroupWithTranslations = popGroupOptions.find(x => x.english === record.population_group)
-            // TODO: refactor backend so that popGroupOptions keys directly map to languages on the frontend
-            const languageTypeMapping = {
-              'en': 'english',
-              'fr': 'french',
-              'de': 'german'
-            }
-            if(popGroupWithTranslations){
-              const lang = languageTypeMapping[state.language]
-              record.population_group = popGroupWithTranslations[lang]
-            }
-
             setSelectedPinId(source_id);
             togglePinBlur(map, source_id);
             pinPopup = new mapboxgl.Popup({ offset: 5, className: "pin-popup" })
               .setLngLat(e.lngLat)
               .setMaxWidth("445px")
-              .setHTML(ReactDOMServer.renderToString(StudyPopup(record, state.language)))
+              .setHTML(ReactDOMServer.renderToString(StudyPopup(record, state.allFilterOptions.population_group)))
               .addTo(map);
             map.flyTo({
               center: [e.lngLat.lng, e.lngLat.lat - 15], //TODO: works for most cases, not sure how to center popup
@@ -143,7 +129,7 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
         setHoveredOverId(e.features[0].properties.source_id)
       })
     }
-  }, [map, state.language, state.allFilterOptions.population_group, api])
+  }, [map, api])
 
   // Changes hover state of each circle
   useEffect(() => {

--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -93,6 +93,21 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
 
         api.getRecordDetails(source_id).then((record) => {
           if (record !== null) {
+            // substitute population group with its translation
+            // TODO: refactor so that we no longer need filter options to be a set
+            const popGroupOptions = Array.from(state.allFilterOptions.population_group);
+            console.log(popGroupOptions)
+            const popGroupWithTranslations = popGroupOptions.find(x => x.english === record.population_group)
+            // TODO: refactor backend so that popGroupOptions keys directly map to languages on the frontend
+            const languageTypeMapping = {
+              'en': 'english',
+              'fr': 'french'
+            }
+            if(popGroupWithTranslations){
+              const lang = languageTypeMapping[state.language]
+              record.population_group = popGroupWithTranslations[lang]
+            }
+
             setSelectedPinId(source_id);
             togglePinBlur(map, source_id);
             pinPopup = new mapboxgl.Popup({ offset: 5, className: "pin-popup" })
@@ -130,7 +145,7 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
         setHoveredOverId(e.features[0].properties.source_id)
       })
     }
-  }, [map, state.language, api])
+  }, [map, state.language, state.allFilterOptions.population_group, api])
 
   // Changes hover state of each circle
   useEffect(() => {

--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -98,7 +98,7 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
             pinPopup = new mapboxgl.Popup({ offset: 5, className: "pin-popup" })
               .setLngLat(e.lngLat)
               .setMaxWidth("445px")
-              .setHTML(ReactDOMServer.renderToString(StudyPopup(record)))
+              .setHTML(ReactDOMServer.renderToString(StudyPopup(record, state.language)))
               .addTo(map);
             map.flyTo({
               center: [e.lngLat.lng, e.lngLat.lat - 15], //TODO: works for most cases, not sure how to center popup

--- a/src/components/map/Layers/StudyPins.tsx
+++ b/src/components/map/Layers/StudyPins.tsx
@@ -96,12 +96,12 @@ const StudyPins = (map: mapboxgl.Map | undefined, {records}: StudyPinsMapConfig)
             // substitute population group with its translation
             // TODO: refactor so that we no longer need filter options to be a set
             const popGroupOptions = Array.from(state.allFilterOptions.population_group);
-            console.log(popGroupOptions)
             const popGroupWithTranslations = popGroupOptions.find(x => x.english === record.population_group)
             // TODO: refactor backend so that popGroupOptions keys directly map to languages on the frontend
             const languageTypeMapping = {
               'en': 'english',
-              'fr': 'french'
+              'fr': 'french',
+              'de': 'german'
             }
             if(popGroupWithTranslations){
               const lang = languageTypeMapping[state.language]

--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { AirtableRecord, LanguageType } from "types";
-import Translate, { TranslateDate } from 'utils/translate/translateService';
+import Translate, { TranslateDate, getLanguageType } from 'utils/translate/translateService';
 import { getGeography } from 'utils/utils';
 import {Divider} from "semantic-ui-react"
 
@@ -29,7 +29,28 @@ function riskTag(riskLevel: string | null | undefined) {
     )
 }
 
-export default function StudyPopup(record: AirtableRecord, language: LanguageType) {
+/**
+ * @param popGroupOptions: List of population group options, each option being a dictionary with key = language and value = translated option string
+ * @param englishPopGroup: English population group string
+ */
+function getTranslatedPopulationGroup(popGroupOptions: Record<string, string>[], englishPopGroup: string){
+    let result = englishPopGroup;
+    const popGroupWithTranslations = popGroupOptions.find(x => x.english === englishPopGroup)
+    // TODO: refactor so that popGroupOptions keys directly map to languages on the frontend
+    const languageTypeMapping = {
+      'en': 'english',
+      'fr': 'french',
+      'de': 'german'
+    }
+
+    if(popGroupWithTranslations){
+      const lang = languageTypeMapping[getLanguageType()]
+      result = popGroupWithTranslations[lang]
+    }
+    return result
+}
+
+export default function StudyPopup(record: AirtableRecord, popGroupOptions: Record<string, string>[]) {
     return (
         <div className="popup-content" >
             <div className={"d-flex justify-content-between mb-1"}>
@@ -49,7 +70,7 @@ export default function StudyPopup(record: AirtableRecord, language: LanguageTyp
                     {row(Translate("SamplingDates"), `${TranslateDate(record.sampling_start_date)} → ${TranslateDate(record.sampling_end_date)}`)}
                 </>)
             }
-            {row(Translate("PopulationGroup"), record.population_group ?? Translate("NotReported"))}
+            {row(Translate("PopulationGroup"), record.population_group ? getTranslatedPopulationGroup(popGroupOptions, record.population_group) : Translate("NotReported"))}
             {row(Translate("BestSeroprevalenceEstimate"),record.serum_pos_prevalence ? `${(record.serum_pos_prevalence * 100).toFixed(1)}%` : "N/A")}
             {row(Translate("SampleSize"), record.denominator_value?.toString().replace(/\B(?=(\d{3})+(?!\d))/g, Translate(",")))}
             {row(Translate("AntibodyTarget"), record.antibody_target && record.antibody_target.length > 0 ? (record.antibody_target.length === 2 ? record.antibody_target.join(", ") : record.antibody_target) : "N/A")}

--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { AirtableRecord } from "types";
+import { AirtableRecord, LanguageType } from "types";
 import Translate from 'utils/translate/translateService';
 import { getGeography, getPossibleNullDateString } from 'utils/utils';
 import {Divider} from "semantic-ui-react"
@@ -29,8 +29,7 @@ function riskTag(riskLevel: string | null | undefined) {
     )
 }
 
-export default function StudyPopup(record: AirtableRecord) {
-
+export default function StudyPopup(record: AirtableRecord, language: LanguageType) {
     return (
         <div className="popup-content" >
             <div className={"d-flex justify-content-between mb-1"}>
@@ -47,7 +46,7 @@ export default function StudyPopup(record: AirtableRecord) {
             {/*{row(Translate(`${record.estimate_grade}StudyDetails`), getGeography(record.city, record.state, record.country))}*/}
             {(record.sampling_start_date && record.sampling_end_date) && (
                 <>
-                    {row(Translate("SamplingDates"), `${getPossibleNullDateString(record.sampling_start_date)} → ${getPossibleNullDateString(record.sampling_end_date)}`)}
+                    {row(Translate("SamplingDates"), `${getPossibleNullDateString(record.sampling_start_date, language)} → ${getPossibleNullDateString(record.sampling_end_date, language)}`)}
                 </>)
             }
             {row(Translate("PopulationGroup"), record.population_group ?? Translate("NotReported"))}

--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AirtableRecord, LanguageType } from "types";
-import Translate from 'utils/translate/translateService';
-import { getGeography, getPossibleNullDateString } from 'utils/utils';
+import Translate, { TranslateDate } from 'utils/translate/translateService';
+import { getGeography } from 'utils/utils';
 import {Divider} from "semantic-ui-react"
 
 /**
@@ -46,7 +46,7 @@ export default function StudyPopup(record: AirtableRecord, language: LanguageTyp
             {/*{row(Translate(`${record.estimate_grade}StudyDetails`), getGeography(record.city, record.state, record.country))}*/}
             {(record.sampling_start_date && record.sampling_end_date) && (
                 <>
-                    {row(Translate("SamplingDates"), `${getPossibleNullDateString(record.sampling_start_date, language)} → ${getPossibleNullDateString(record.sampling_end_date, language)}`)}
+                    {row(Translate("SamplingDates"), `${TranslateDate(record.sampling_start_date)} → ${TranslateDate(record.sampling_end_date)}`)}
                 </>)
             }
             {row(Translate("PopulationGroup"), record.population_group ?? Translate("NotReported"))}

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -79,19 +79,7 @@ export default class httpClient {
     async getAllFilterOptions() {
         const response = await this.httpGet(FILTER_OPTIONS_URL, true);
 
-        const options: Record<string, any> = {}
-        for(let k in response){
-            // Currently no need for max and min date options
-            //Note: From Himanshu: I changed the values of the string here
-            // because I noticed the backend response did not have a max_date and min_date value
-            //but it did have what is below.
-            if(k !== "max_publication_end_date" && k !== "min_publication_end_date"){
-                // For all the other options, use a Set instead of list
-                // Because that's the data model our filters are used to
-                // TODO: refactor so we can keep filter options in a list
-                options[k] = new Set(response[k]);
-            }
-        }
+        const options: Record<string, any> = response;
         // We know that only these 3 isotypes will ever be reported, thus we can hardcode
         options.isotypes_reported = ["IgG", "IgA", "IgM"];
         const updatedAt = format(parseISO(response.updated_at), "yyyy/MM/dd");

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,7 +48,7 @@ export type FiltersConfig = {
   source_type: string[];
   test_type: string[];
   country: string[];
-  population_group: string[];
+  population_group: Record<string, string>[];
   sex: string[];
   age: string[];
   overall_risk_of_bias: string[];

--- a/src/utils/translate/translateService.ts
+++ b/src/utils/translate/translateService.ts
@@ -125,3 +125,19 @@ export function TranslateObject(text: string): object {
     return { error: `No translation object for string ${text}` };
   }
 }
+
+/**
+ * Used to translate and localize dates
+ * @param dateString
+ * @returns string
+ */
+ export function TranslateDate(dateString: string): string {
+
+  const dateTimeFormat = new Intl.DateTimeFormat(language, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  
+  return dateTimeFormat.format(new Date(dateString))
+}

--- a/src/utils/translate/translateService.ts
+++ b/src/utils/translate/translateService.ts
@@ -54,6 +54,10 @@ const recursiveFind = (object: any, keys: string[], index: number): string => {
 
 let language: LanguageType = LanguageType.english;
 
+export const getLanguageType = () => {
+  return language;
+}
+
 export const setLanguageType = (newLanguage: LanguageType) => {
   setLanguage(newLanguage);
   language = newLanguage;

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { format, parseISO, formatISO, add } from "date-fns";
+import { formatISO, add } from "date-fns";
 import Translate from 'utils/translate/translateService';
 import { LanguageType } from "../types";
 
@@ -19,35 +18,6 @@ export const formatDates = (dates: Array<Date> | null) => {
     startDate = dateList[0] ? formatISO(dateList[0] as Date) : startDate;
   }
   return [startDate, endDate]
-}
-
-
-export const getPossibleNullString = (nullString: string | number | null | undefined) => {
-  if (nullString === null || nullString === undefined) {
-    return Translate("Not Reported")
-  }
-  return nullString
-}
-
-export const getPossibleNullDateString = (nullString: string | null | undefined, language: LanguageType) => {
-  if (nullString === null || nullString === undefined) {
-    return Translate("Not Reported")
-  }
-
-  const dateTimeFormat = new Intl.DateTimeFormat(language, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-
-  return dateTimeFormat.format(new Date(nullString))
-}
-
-export const getPossibleNullStringArray = (nullString: string[] | null | undefined) => {
-  if (nullString === null || nullString === undefined) {
-    return Translate("Not Reported")
-  }
-  return nullString.join(", ")
 }
 
 export const getGeography = (city: string[] | null | undefined, state: string[] | null | undefined, country: string | null) => {

--- a/src/utils/utils.tsx
+++ b/src/utils/utils.tsx
@@ -29,12 +29,12 @@ export const getPossibleNullString = (nullString: string | number | null | undef
   return nullString
 }
 
-export const getPossibleNullDateString = (nullString: string | null | undefined) => {
+export const getPossibleNullDateString = (nullString: string | null | undefined, language: LanguageType) => {
   if (nullString === null || nullString === undefined) {
     return Translate("Not Reported")
   }
 
-  const dateTimeFormat = new Intl.DateTimeFormat('en', {
+  const dateTimeFormat = new Intl.DateTimeFormat(language, {
     year: 'numeric',
     month: 'long',
     day: 'numeric',


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Translates study modal date and population group
- Removes unnecessary array -> set conversions
- Fixes bug where after switching languages, multiple study modals are rendered on click (see this [commit](https://github.com/serotracker/sero-can-webapp/commit/b3afde5dcbe4b6f10be2ac691938b5a6dfeed962))

Note about the last bugfix: The bug was being caused by us registering multiple on click events every time `state.language` was updated. Thus in order to resolve the issues, we needed to find a way to write the useEffect that generated the study popup without having it depend on `state.language`. The bug and fix are a but confusing, open to suggestions on better fixes.

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
