### PR TITLE
PageBody

### DIFF
--- a/src/components/pages/Analyze.tsx
+++ b/src/components/pages/Analyze.tsx
@@ -3,7 +3,7 @@ import React, { useContext } from "react";
 import { AppContext } from "context";
 import { ANALYZE_URLS, PAGE_HASHES, mobileDeviceOrTabletWidth } from "../../constants";
 import { useMediaQuery } from "react-responsive";
-import TableauEmbed from "components/shared/TableauEmbed";
+import TableauEmbed from "components/shared/TableauEmbed/TableauEmbed";
 import "./static.css";
 
 const ANALYZE_MOBILE_HEIGHT = 2900;
@@ -16,7 +16,7 @@ export default function Analyze() {
   });
   const [{ language }] = useContext(AppContext);
 
-  // function to calculate the number of pixels from the top of the page 
+  // function to calculate the number of pixels from the top of the page
   // the nth chart (0-indexed) is
   // note: this assumes that charts are the same height
   const getOffsetForGraphNum = (n: number) => {

--- a/src/components/pages/Partnerships/CanadaPartnership.tsx
+++ b/src/components/pages/Partnerships/CanadaPartnership.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from "react";
 import { Partnership } from "types";
 import { AppContext } from "../../../context";
-import TableauEmbed from "components/shared/TableauEmbed";
+import TableauEmbed from "components/shared/TableauEmbed/TableauEmbed";
 import Translate, { getCountryName } from "utils/translate/translateService";
 import PartnerShipsMap from "components/partnerships/PartnershipsMap";
 
@@ -19,7 +19,7 @@ export default function CanadaPartnership({partnershipConfig}:CanadaPartnershipP
         {Translate("PartnershipsPageDescription", [partnershipConfig.routeName, "PartOne"], null, [false, true])}
         <a target="_blank" rel="noopener noreferrer" href="https://www.covid19immunitytaskforce.ca/">
           {Translate("PartnershipsPageDescription", [partnershipConfig.routeName, "PartTwo"], null, [false, true])}
-        </a> 
+        </a>
         {Translate("PartnershipsPageDescription", [partnershipConfig.routeName, "PartThree"])}
       </div>
       <div className="mt-5 mb-1">
@@ -30,20 +30,19 @@ export default function CanadaPartnership({partnershipConfig}:CanadaPartnershipP
         </h3>
       </div>
       <PartnerShipsMap partnershipconfig={partnershipConfig} />
-      <div className="row">
-        <TableauEmbed
-          url={partnershipConfig.tableauUrl}
-          key={partnershipConfig.tableauKey}
-          desktopOptions={{
-            width: "83vw",
-            height: "6000px",
-          }}
-          mobileOptions={{
-            width: "90vw",
-            height: "3000px",
-          }}
-        />
-      </div>
+      <TableauEmbed
+        className="row"
+        url={partnershipConfig.tableauUrl}
+        key={partnershipConfig.tableauKey}
+        desktopOptions={{
+          width: "100%",
+          height: "6000px",
+        }}
+        mobileOptions={{
+          width: "100%",
+          height: "2700px",
+        }}
+      />
     </>
   );
 }

--- a/src/components/pages/Partnerships/Partnerships.tsx
+++ b/src/components/pages/Partnerships/Partnerships.tsx
@@ -1,10 +1,9 @@
 import React from "react";
 import { Redirect, useParams } from "react-router-dom";
-import { isMaintenanceMode } from "../../../constants";
 import { Partnership } from "types";
-import MaintenanceModal from "../../shared/MaintenanceModal";
 import PartnershipsConfig from "PartnershipsConfig";
-import CanadaPartnership from 'components/pages/Partnerships/CanadaPartnership'
+import CanadaPartnership from 'components/pages/Partnerships/CanadaPartnership';
+import PageBody from '../../shared/PageBody'
 
 type PartnershipProps = {
   partnershipConfig: Partnership;
@@ -17,7 +16,7 @@ function RenderSelectedPartnershipComponent({partnershipConfig}: PartnershipProp
       partnership = <CanadaPartnership partnershipConfig={partnershipConfig}/>
       break;
     // Add more cases for new parnership components here.
-  } 
+  }
 
   return partnership
 }
@@ -29,14 +28,9 @@ export default function Partnerships() {
   return (
     <>
       {config !== undefined ? (
-        <>
-          <div className="col-12 page pb-6">
-            <div className="col-10">
-              {RenderSelectedPartnershipComponent({partnershipConfig: config})}
-            </div>
-          </div>
-          <MaintenanceModal isOpen={isMaintenanceMode} headerText={""} />
-        </>
+        <PageBody includeMaintenanceModal>
+          {RenderSelectedPartnershipComponent({partnershipConfig: config})}
+        </PageBody>
       ) : (
         <Redirect to="/404" />
       )}

--- a/src/components/shared/PageBody.tsx
+++ b/src/components/shared/PageBody.tsx
@@ -16,7 +16,7 @@ const PageBody = (props: TableauEmbedProps) => {
         {props.children}
       </div>
     </div>
-    {props.includeMaintenanceModal ? <MaintenanceModal isOpen={isMaintenanceMode} headerText={""} /> : ''}
+    {props.includeMaintenanceModal && <MaintenanceModal isOpen={isMaintenanceMode} headerText={""} /> }
   </div>
   )
 }

--- a/src/components/shared/PageBody.tsx
+++ b/src/components/shared/PageBody.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { isMaintenanceMode } from "../../constants";
+import MaintenanceModal from "../shared/MaintenanceModal";
+
+interface TableauEmbedProps {
+    className?: string,
+    children?: JSX.Element | JSX.Element[];
+    includeMaintenanceModal: boolean,
+}
+
+const PageBody = (props: TableauEmbedProps) => {
+  return (
+    <div className={`container ${props.className}`}>
+    <div className="row">
+      <div className="col-md-auto">
+        {props.children}
+      </div>
+    </div>
+    {props.includeMaintenanceModal ? <MaintenanceModal isOpen={isMaintenanceMode} headerText={""} /> : ''}
+  </div>
+  )
+}
+
+export default PageBody

--- a/src/components/shared/TableauEmbed/TableauEmbed.scss
+++ b/src/components/shared/TableauEmbed/TableauEmbed.scss
@@ -1,0 +1,8 @@
+@import '../../../sass/variables.scss';
+
+
+.tableau-embed {
+    > div {
+        width: 100%;
+    }
+}

--- a/src/components/shared/TableauEmbed/TableauEmbed.tsx
+++ b/src/components/shared/TableauEmbed/TableauEmbed.tsx
@@ -2,17 +2,27 @@ import React, { useContext } from "react";
 // @ts-ignore
 // The tableau JS API does not have good typescript support
 import TableauReport from 'tableau-react-embed';
-import '../pages/static.css';
+import '../../pages/static.css';
 import { useMediaQuery } from "react-responsive";
-import { mobileDeviceOrTabletWidth } from "../../constants";
-import { LanguageType } from "../../types";
-import { AppContext } from "../../context";
+import { mobileDeviceOrTabletWidth } from "../../../constants";
+import { LanguageType } from "../../../types";
+import { AppContext } from "../../../context";
+import './TableauEmbed.scss';
 
 interface TableauEmbedProps {
+    className?: string,
     url: { [key in LanguageType]?: string },
     mobileOptions?: Record<string, string>,
     desktopOptions?: Record<string, string>
 }
+
+// All other vizCreate options are supported here, too
+// They are listed here:
+// https://onlinehelp.tableau.com/current/api/js_api/en-us/JavaScriptAPI/js_api_ref.htm#ref_head_9
+// const options = {
+//     width: "100%",
+//     height: "100%"
+// }
 
 export default function TableauEmbed(props: TableauEmbedProps) {
     const [{ language }, dispatch] = useContext(AppContext);
@@ -27,17 +37,9 @@ export default function TableauEmbed(props: TableauEmbedProps) {
         options = props.desktopOptions ? props.desktopOptions : {}
     }
 
-     // All other vizCreate options are supported here, too
-    // They are listed here:
-    // https://onlinehelp.tableau.com/current/api/js_api/en-us/JavaScriptAPI/js_api_ref.htm#ref_head_9
-    // const options = {
-    //     width: "100%",
-    //     height: "100%"
-    // }
     return (
-        <TableauReport id = "iframe"
-            url={url}
-            options={options}
-        />
+    <figure className={`tableau-embed ${props.className}`}>
+        <TableauReport url={url} options={options}/>
+    </figure>
     )
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
This PR adds a new component,`PageBody` to help create uniform pages site-wide, without lots of divs & css.
Wrote style in bootstrap grid; allowing for better breakpoints and compatibility with other layouts.
Rewrote the structure, and style of `Partnerships` page to make use of the new page body component. This will act as an example of how to use it.


## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwKscR1ZvgkUxVtA/recb6fCvOTyjYln6U?blocks=hide
## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

Example of new pagebody component on 1920px width monitor:
![image](https://user-images.githubusercontent.com/22464147/148307856-82072f8a-d7bb-41aa-84db-4e249d6bb206.png)
