### PR TITLE
Fixing biblio link for Dec 17

### DIFF
--- a/src/components/pages/Publications/PublicationsConstants.ts
+++ b/src/components/pages/Publications/PublicationsConstants.ts
@@ -387,19 +387,19 @@ export const listOfBiblioDigests: BiblioDigestProps[] = [
         screeningEndDate: "2021-01-07"
     },
     {
-        url: "https://drive.google.com/file/d/1u2g7tmbP9kD0oi0syLgapmoBP4BCV0NF/view?usp=sharing",
-        sourcesAdded: 56,
-        serosurveysTotal: 118,
+        url: "https://drive.google.com/file/d/1ibebgdbG5C-k0whOJfjeEuECrybmHlQ2/view?usp=sharing",
+        sourcesAdded: 85,
+        serosurveysTotal: 176,
         serosurveysAFRO: 37,
-        serosurveysEMRO: 2,
-        serosurveysEURO: 39,
-        serosurveysPAHO: 24,
-        serosurveysSEARO: 5,
-        serosurveysWPRO: 10,
+        serosurveysEMRO: 5,
+        serosurveysEURO: 67,
+        serosurveysPAHO: 40,
+        serosurveysSEARO: 11,
+        serosurveysWPRO: 15,
         serosurveysNonMember: 1,
-        publishDate: "2021-12-10",
+        publishDate: "2021-12-17",
         screeningStartDate: "2021-11-20",
-        screeningEndDate: "2021-12-03"
+        screeningEndDate: "2021-12-10"
     },
     {
         url: "https://drive.google.com/file/d/1v1Tzyatwzg-1v7f0H6qO1JGfL9Hk3_jN/view?usp=sharing",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Link to dec 17 biblio was pointing to Nov 26

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
