### PR TITLE
Address tech debt with Github button download ticket

### DIFF
--- a/src/components/pages/Data.tsx
+++ b/src/components/pages/Data.tsx
@@ -8,6 +8,7 @@ import Translate, { TranslateObject } from "../../utils/translate/translateServi
 import "./static.css";
 import MaintenanceModal from "../shared/MaintenanceModal";
 import DownloadButton from "../shared/DownloadButton";
+import {IconName} from "../../types";
 interface DropdownQuestion {
   Question: string;
   Answer: string | object;
@@ -59,7 +60,7 @@ function DataButtons() {
     buttonLabelKey: "DownloadCsv", 
     downloadLink: "https://airtable.com/shraXWPJ9Yu7ybowM/tbljN2mhRVfSlZv2d?backgroundColor=blue&viewControls=on" ,
     formLink: "https://docs.google.com/forms/d/e/1FAIpQLSdGd_wlq8YSyVPs2AOi1VfvxuLzxA8Ye5I3HkQwW_9yrumsCg/viewform" ,
-    iconName: "",
+    iconName: IconName.airtable,
     popupText: "DownloadAirtable",
   }
 
@@ -68,7 +69,7 @@ function DataButtons() {
     buttonLabelKey: "AccessGithub", 
     downloadLink: "https://github.com/serotracker/sars-cov-2-data" ,
     formLink: "https://docs.google.com/forms/d/e/1FAIpQLSdGd_wlq8YSyVPs2AOi1VfvxuLzxA8Ye5I3HkQwW_9yrumsCg/viewform" ,
-    iconName: "github",
+    iconName: IconName.github,
     popupText: "DownloadGithub",
   }
 

--- a/src/components/pages/Data.tsx
+++ b/src/components/pages/Data.tsx
@@ -77,12 +77,16 @@ function DataButtons() {
     <div>
       {buttons}
       <span>
-        <DownloadButton
-        {...airtableDownloadProps}
-        />
-        <DownloadButton
-        {...githubDownloadProps}
-        />
+        <span className="mr-2">
+          <DownloadButton
+          {...airtableDownloadProps}
+          />
+        </span>
+        <span className="mr-2">
+          <DownloadButton
+          {...githubDownloadProps}
+          />
+        </span>
       </span>
     </div>
   );

--- a/src/components/shared/DownloadButton.tsx
+++ b/src/components/shared/DownloadButton.tsx
@@ -5,11 +5,12 @@ import { Button, Popup } from "semantic-ui-react";
 import { Icon } from 'semantic-ui-react';
 import { SemanticICONS } from "semantic-ui-react/dist/commonjs/generic";
 import airtableLogo from '../../assets/images/airtable-icon.svg';
+import { IconName } from '../../types';
 interface DownloadButtonProps {
     buttonLabelKey?: string;
     downloadLink?: string;
     formLink?: string;
-    iconName: string;
+    iconName: IconName;
     popupText: string;
     id?: string;
   }
@@ -43,8 +44,8 @@ export default function DownloadButton(props: DownloadButtonProps) {
     }
     
     return (
-        iconName === "" ?       
-        <Popup content={Translate(popupText)} style={{textAlign: "left"}} position="top right" trigger={
+        iconName === IconName.airtable ?       
+        <Popup  popperModifiers={{ preventOverflow: { boundariesElement: "window" } }} content={Translate(popupText)} size="small" style={{textAlign: "left"}} position="top left" trigger={
             <Button key={buttonLabelKey} size="large" iconName={iconName} className="download-data-btn mb-2 mr-2" id={props.id} >
                 <a
                     onClick={() => clickButton()}
@@ -61,8 +62,8 @@ export default function DownloadButton(props: DownloadButtonProps) {
   
     :  
 
-    <Popup id={props.id} offset={-10} style={{textAlign: "left"}}content={Translate(popupText)} position="top right" trigger={
-        <Button id={props.id} key={buttonLabelKey} size="large" iconName={iconName} className="download-data-btn mb-2 mr-2">
+    <Popup  popperModifiers={{ preventOverflow: { boundariesElement: "window" } }} id={props.id} size="small" style={{textAlign: "left"}}content={Translate(popupText)} position="top left" trigger={
+        <Button id={props.id} key={buttonLabelKey}  size="large" iconName={iconName} className="download-data-btn mb-2 mr-2">
             <a
                 onClick={() => clickButton()}
                 target="_blank"

--- a/src/components/shared/DownloadButton.tsx
+++ b/src/components/shared/DownloadButton.tsx
@@ -50,7 +50,7 @@ export default function DownloadButton(props: DownloadButtonProps) {
                 <a
                     onClick={() => clickButton()}
                     target="_blank"
-                    rel="noreferrer"
+                    rel="noopener noreferrer"
                     href={getButtonLink()}
                     className='d-flex align-items-center'
                 >
@@ -67,7 +67,7 @@ export default function DownloadButton(props: DownloadButtonProps) {
             <a
                 onClick={() => clickButton()}
                 target="_blank"
-                rel="noreferrer"
+                rel="noopener noreferrer"
                 href={getButtonLink()}
                 className='d-flex align-items-center'
             >

--- a/src/components/shared/DownloadButton.tsx
+++ b/src/components/shared/DownloadButton.tsx
@@ -46,7 +46,7 @@ export default function DownloadButton(props: DownloadButtonProps) {
     return (
         iconName === IconName.airtable ?       
         <Popup  popperModifiers={{ preventOverflow: { boundariesElement: "window" } }} content={Translate(popupText)} size="small" style={{textAlign: "left"}} position="top left" trigger={
-            <Button key={buttonLabelKey} size="large" iconName={iconName} className="download-data-btn mb-2 mr-2" id={props.id} >
+            <Button key={buttonLabelKey} size="large" iconName={iconName} className="download-data-btn mb-2" id={props.id} >
                 <a
                     onClick={() => clickButton()}
                     target="_blank"
@@ -63,7 +63,7 @@ export default function DownloadButton(props: DownloadButtonProps) {
     :  
 
     <Popup  popperModifiers={{ preventOverflow: { boundariesElement: "window" } }} id={props.id} size="small" style={{textAlign: "left"}}content={Translate(popupText)} position="top left" trigger={
-        <Button id={props.id} key={buttonLabelKey}  size="large" iconName={iconName} className="download-data-btn mb-2 mr-2">
+        <Button id={props.id} key={buttonLabelKey}  size="large" iconName={iconName} className="download-data-btn mb-2">
             <a
                 onClick={() => clickButton()}
                 target="_blank"

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -4,6 +4,7 @@ import TotalStats from "./TotalStats";
 import { Divider } from 'semantic-ui-react'
 import DownloadButton from "components/shared/DownloadButton";
 import { PAGE_HASHES } from "../../../constants";
+import {IconName} from "../../../types";
 import "../sidebar.scss";
 
 interface SideBarProps {
@@ -16,7 +17,7 @@ export default function LeftSidebar({ page }: SideBarProps) {
     buttonLabelKey: "DownloadCsv", 
     downloadLink: "https://airtable.com/shraXWPJ9Yu7ybowM/tbljN2mhRVfSlZv2d?backgroundColor=blue&viewControls=on" ,
     formLink: "https://docs.google.com/forms/d/e/1FAIpQLSdGd_wlq8YSyVPs2AOi1VfvxuLzxA8Ye5I3HkQwW_9yrumsCg/viewform" ,
-    iconName: "",
+    iconName: IconName.airtable,
     popupText: "DownloadAirtable"
   }
 
@@ -24,7 +25,7 @@ export default function LeftSidebar({ page }: SideBarProps) {
     buttonLabelKey: "AccessGithub", 
     downloadLink: "https://github.com/serotracker/sars-cov-2-data" ,
     formLink: "https://docs.google.com/forms/d/e/1FAIpQLSdGd_wlq8YSyVPs2AOi1VfvxuLzxA8Ye5I3HkQwW_9yrumsCg/viewform" ,
-    iconName: "github",
+    iconName: IconName.github,
     popupText: "DownloadGithub"
   }
 

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -70,6 +70,7 @@
     a {
         color: white;
     }
+    margin: 0;
 }
 
 .cite-link {

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,3 +193,8 @@ export enum AggregationFactor {
   overall_risk_of_bias = "overall_risk_of_bias",
   isotypes_reported = "isotypes_reported",
 }
+
+export enum IconName {
+  airtable = "",
+  github = "github"
+}


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Fixes tech debt with download buttons:
- Adds types
- Fixes positioning of popup
- Fixes margins in styling

## Please link the Airtable ticket associated with this PR.
[Address tech debt with Github button download ticket](https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwTYqtBDdt3Wt3Yo/recpBHWgZYDnanVif?blocks=hide)

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.
Nope!

## Does this PR require any French translations? Have they been included?
Nope!

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
