### PR TITLE
Subscription popup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
 
     allFilterOptions();
 
-    //track if user is a return user or not
+    //track if user is a return user or not. if returnUser does not exist this is the users first time
     if(!localStorage.getItem("returnUser")) {
       localStorage.setItem("returnUser", "true")
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,12 @@ function App() {
     }
 
     allFilterOptions();
+
+    //track if user is a return user or not
+    if(!localStorage.getItem("returnUser")) {
+      localStorage.setItem("returnUser", "true")
+    }
+
     // We only want this to run once so we pass no dependencies. Do not remove this
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import httpClient from "./httpClient";
 import { LanguageType } from "./types";
 import { setLanguageType } from "./utils/translate/translateService";
 import Partnerships from "components/pages/Partnerships/Partnerships";
+import NewsletterPopup from "./components/shared/NewsletterPopup";
 
 function App() {
   const [{ language, explore }, dispatch] = useContext(AppContext);
@@ -95,6 +96,7 @@ function App() {
     <div className="App">
       <Header />
       <CookieBanner />
+      <NewsletterPopup />
       <Switch>
         <Route path="/:language/About">
           <About />

--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -40,14 +40,7 @@ export default function Explore({initialFilters}: ExploreProps) {
                 sendUnityAnalyticsEvent();
             }
         }
-        if(localStorage.getItem("returnUser") == null) {
-            localStorage.setItem("returnUser", "false")
-        }
-        else {
-            if(!localStorage.getItem("returnUser")){
-                localStorage.setItem("returnUser", "true")
-            }
-        }
+
         fetchExploreData(dispatch, state.explore.filters, PageStateEnum.explore)
         // We only want this to run once so we pass no dependencies. Do not remove this
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -40,6 +40,14 @@ export default function Explore({initialFilters}: ExploreProps) {
                 sendUnityAnalyticsEvent();
             }
         }
+        if(localStorage.getItem("returnUser") == null) {
+            localStorage.setItem("returnUser", "false")
+        }
+        else {
+            if(!localStorage.getItem("returnUser")){
+                localStorage.setItem("returnUser", "true")
+            }
+        }
         fetchExploreData(dispatch, state.explore.filters, PageStateEnum.explore)
         // We only want this to run once so we pass no dependencies. Do not remove this
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -5,14 +5,21 @@ export default function NewsletterPopup() {
     const [hidden, setHidden] = useState(true)
 
     useEffect(() => {
-        setTimeout(function () {
-            setHidden(false)
-        }, 30000) // 1 minute in ms
+        if (!localStorage.getItem("SubscribePopupSeen")){
+            setTimeout(function () {
+                setHidden(false)
+            }, 30000) // 30 seconds in ms
+        }
     }, [])
+
+    const onClickHandle = () => {
+        setHidden(true)
+        localStorage.setItem("SubscribePopupSeen", "true")
+    }
 
     return (
         <div className={"popup"} style={{visibility: hidden ? "hidden" : "visible"}}>
-            <Button className={"popup-close-button"} icon onClick={() => {setHidden(true)}}>
+            <Button className={"popup-close-button"} icon onClick={onClickHandle}>
                 <Icon className={"popup-close-button-icon"} name={"close"} />
             </Button>
             <iframe

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -6,7 +6,7 @@ export default function NewsletterPopup() {
 
     useEffect(() => {
         if (!localStorage.getItem("SubscribePopupSeen")){
-            if(localStorage.getItem("returnUser")) {
+            if(localStorage.getItem("returnUser") === "true") {
                 setTimeout(function () {
                     setHidden(false)
                 }, 30000) // 30 seconds in ms

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -6,9 +6,11 @@ export default function NewsletterPopup() {
 
     useEffect(() => {
         if (!localStorage.getItem("SubscribePopupSeen")){
-            setTimeout(function () {
-                setHidden(false)
-            }, 30000) // 30 seconds in ms
+            if(localStorage.getItem("returnUser")) {
+                setTimeout(function () {
+                    setHidden(false)
+                }, 30000) // 30 seconds in ms
+            }
         }
     }, [])
 

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -1,0 +1,27 @@
+import React, {useEffect, useState} from "react";
+import {Button, Icon} from "semantic-ui-react";
+
+export default function NewsletterPopup() {
+    const [hidden, setHidden] = useState(true)
+
+    useEffect(() => {
+        setTimeout(function () {
+            setHidden(false)
+        }, 30000) // 1 minute in ms
+    }, [])
+
+    return (
+        <div className={"popup"} style={{visibility: hidden ? "hidden" : "visible"}}>
+            <Button className={"popup-close-button"} icon onClick={() => {setHidden(true)}}>
+                <Icon className={"popup-close-button-icon"} name={"close"} />
+            </Button>
+            <iframe
+                src="https://serotracker.substack.com/embed"
+                width="480" height="320"
+                className={"popup-content"}
+                frameBorder="0"
+                scrolling="no"
+            />
+        </div>
+    )
+}

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -20,14 +20,14 @@ export default function NewsletterPopup() {
     }
 
     return (
-        <div className={"popup"} style={{visibility: hidden ? "hidden" : "visible"}}>
-            <Button className={"popup-close-button"} icon onClick={onClickHandle}>
-                <Icon className={"popup-close-button-icon"} name={"close"} />
+        <div className={"newsletter-popup"} style={{visibility: hidden ? "hidden" : "visible"}}>
+            <Button className={"newsletter-popup-close-button"} icon onClick={onClickHandle}>
+                <Icon className={"newsletter-popup-close-button-icon"} name={"close"} />
             </Button>
             <iframe
                 src="https://serotracker.substack.com/embed"
                 width="480" height="320"
-                className={"popup-content"}
+                className={"newsletter-popup-content"}
                 frameBorder="0"
                 scrolling="no"
             />

--- a/src/components/shared/NewsletterPopup.tsx
+++ b/src/components/shared/NewsletterPopup.tsx
@@ -9,6 +9,7 @@ export default function NewsletterPopup() {
             if(localStorage.getItem("returnUser") === "true") {
                 setTimeout(function () {
                     setHidden(false)
+                    localStorage.setItem("SubscribePopupSeen", "true")
                 }, 30000) // 30 seconds in ms
             }
         }
@@ -16,11 +17,10 @@ export default function NewsletterPopup() {
 
     const onClickHandle = () => {
         setHidden(true)
-        localStorage.setItem("SubscribePopupSeen", "true")
     }
 
     return (
-        <div className={"newsletter-popup"} style={{visibility: hidden ? "hidden" : "visible"}}>
+        <div className={"newsletter-popup"} onClick={onClickHandle} style={{visibility: hidden ? "hidden" : "visible"}}>
             <Button className={"newsletter-popup-close-button"} icon onClick={onClickHandle}>
                 <Icon className={"newsletter-popup-close-button-icon"} name={"close"} />
             </Button>

--- a/src/sass/components/shared.scss
+++ b/src/sass/components/shared.scss
@@ -36,3 +36,41 @@ div#root div.App div.static-content table tbody tr.highlight {
   opacity: 0;
   position: absolute;
 }
+
+.popup {
+  position: absolute;
+  top: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  //opacity: 0.3;
+  width: 100vw;
+  height: 100vh;
+  z-index: 999;
+
+  &-content {
+    position: absolute;
+    width: 500px;
+    height: 300px;
+    top: calc(50vh - 150px);
+    left: calc(50vw - 250px);
+    border: 1px solid #EEE;
+    background: white;
+  }
+
+  &-close-button {
+    position: absolute;
+    top: calc(50vh - 150px);
+    right: calc(50vw - 250px);
+    z-index: 1000;
+    background-color: white !important;
+    //TODO: fix padding issue
+    padding: 0;
+
+    &:hover {
+      background-color: lightgray !important;
+    }
+
+
+  }
+
+}

--- a/src/sass/components/shared.scss
+++ b/src/sass/components/shared.scss
@@ -37,7 +37,7 @@ div#root div.App div.static-content table tbody tr.highlight {
   position: absolute;
 }
 
-.popup {
+.newsletter-popup {
   position: absolute;
   top: 0;
   left: 0;


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Added in subscription popu
- Shows up 30 seconds after user visits the website for the second time
- added in local storage vars to track if this is a first visit, and or if the user has seen and closed the sub popup or not.
## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recL30w8N78X6tHep?blocks=hide
## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.
Tested the setting and unseting of variabels n many pages.
Tested interaction and timing of popup and made sure the functional flow is as expected. 
## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
