### PR TITLE
Changing "-->" to "to" between dates on study modal

### DIFF
--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -69,7 +69,7 @@ export default function StudyPopup(record: AirtableRecord, popGroupOptions: Reco
                 <div className={"popup-text"}>
                     {(record.sampling_start_date && record.sampling_end_date) && (
                         <>
-                            {`${TranslateDate(record.sampling_start_date)} ${TranslateDate("DateRangeTo")} ${TranslateDate(record.sampling_end_date)}`}
+                            {`${TranslateDate(record.sampling_start_date)} ${Translate("DateRangeTo")} ${TranslateDate(record.sampling_end_date)}`}
                         </>)
                     }
                 </div>

--- a/src/components/map/Popups/StudyPopup.tsx
+++ b/src/components/map/Popups/StudyPopup.tsx
@@ -69,7 +69,7 @@ export default function StudyPopup(record: AirtableRecord, popGroupOptions: Reco
                 <div className={"popup-text"}>
                     {(record.sampling_start_date && record.sampling_end_date) && (
                         <>
-                            {`${TranslateDate(record.sampling_start_date)} → ${TranslateDate(record.sampling_end_date)}`}
+                            {`${TranslateDate(record.sampling_start_date)} ${TranslateDate("DateRangeTo")} ${TranslateDate(record.sampling_end_date)}`}
                         </>)
                     }
                 </div>

--- a/src/utils/translate/de.json
+++ b/src/utils/translate/de.json
@@ -412,6 +412,7 @@
   "PlannedSerosurveys": "Geplante Serosurveys",
   "Population": "Bevölkerung",
   "PopulationGroup": "Bevölkerungsgruppe",
+  "DateRangeTo": "bis",
   "PopulationGroupOptions": {
     "All": "Alle",
     "BloodDonors": "Blutspendende",
@@ -432,7 +433,7 @@
     "Unspecified": "Nicht spezifiziert"
   },
   "Populations": "Bevölkerungen",
-  "PositiveCases": "Positive cases",
+  "PositiveCases": "Positive Fälle",
   "Prevalence": "Prävalenz",
   "PrevalenceEstimateDetails": "Details zur Prävalenzschätzung",
   "PrivacyPolicy": "Datenschutzrichtlinie",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -137,6 +137,7 @@
   "Dashboard": "Dashboard",
   "Data": "Data",
   "DatabaseUptoDateTo": "Database up to date to",
+  "DateRangeTo": "to",
   "DataDictionary": "Data dictionary",
   "DataDictionaryText": {
     "FirstParagraph": "For more information and context about our data, please take a look at our",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -132,7 +132,7 @@
   "Dashboard": "Tableau de bord",
   "Data": "Données",
   "DatabaseUptoDateTo": "Base de données à jour jusqu'au",
-  "DateRangeTo": "à",
+  "DateRangeTo": "au",
   "DataDictionary": "Dictionnaire de données",
   "DataDictionaryText": {
     "FirstParagraph": "Pour plus d'informations et de contexte sur nos données, veuillez s'il vous plait consulter notre",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -132,6 +132,7 @@
   "Dashboard": "Tableau de bord",
   "Data": "Données",
   "DatabaseUptoDateTo": "Base de données à jour jusqu'au",
+  "DateRangeTo": "à",
   "DataDictionary": "Dictionnaire de données",
   "DataDictionaryText": {
     "FirstParagraph": "Pour plus d'informations et de contexte sur nos données, veuillez s'il vous plait consulter notre",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Changing the arrow between the dates on the study modal to the word "to"
- Fixing a german word that wasn't translated

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
