### PR TITLE
Adding new paper and biblio to pubs page

### DIFF
--- a/src/components/pages/Publications/PublicationsConstants.ts
+++ b/src/components/pages/Publications/PublicationsConstants.ts
@@ -88,6 +88,15 @@ export const listOfReports: PublicationProps[] = [
 
 export const listOfResearchArticles: PublicationProps[] = [
     {
+        date: "2022-02-25",
+        img: MedRxiv,
+        titleKey1: 'ResearchArticleTitles',
+        titleKey2: ['MedRxivNLP'],
+        publicationName: "medRxiv",
+        authors: "Sara Perlman-Arrow, Noel Loo, Niklas Bobrovitz et al.",
+        url: "https://www.medrxiv.org/content/10.1101/2022.02.24.22268947v1"
+    },
+    {
         date: "2021-12-15",
         img: MedRxiv,
         titleKey1: 'ResearchArticleTitles',
@@ -357,6 +366,21 @@ export const listOfMediaPublicationsProps: PublicationProps[] = [
 // Note: for biblio digests, date = date published
 export const listOfBiblioDigests: BiblioDigestProps[] = [
     {
+        url: "https://drive.google.com/file/d/1h7RpDI_EWi2qu2KTjErME03jlhY1hS5Y/view?usp=sharing",
+        sourcesAdded: 128,
+        serosurveysTotal: 310,
+        serosurveysAFRO: 29,
+        serosurveysEMRO: 4,
+        serosurveysEURO: 185,
+        serosurveysPAHO: 58,
+        serosurveysSEARO: 21,
+        serosurveysWPRO: 13,
+        serosurveysNonMember: 0,
+        publishDate: "2022-03-10",
+        screeningStartDate: "2022-02-05",
+        screeningEndDate: "2022-03-04"
+    },
+    {
         url: "https://drive.google.com/file/d/1PME1WFA-ItYAzzuPfGNSvLvJyKXQAezl/view?usp=sharing",
         sourcesAdded: 98,
         serosurveysTotal: 160,
@@ -368,8 +392,8 @@ export const listOfBiblioDigests: BiblioDigestProps[] = [
         serosurveysWPRO: 20,
         serosurveysNonMember: 1,
         publishDate: "2022-02-11",
-        screeningStartDate: "2021-01-08",
-        screeningEndDate: "2021-02-04"
+        screeningStartDate: "2022-01-08",
+        screeningEndDate: "2022-02-04"
     },
     {
         url: "https://drive.google.com/file/d/1J51-liWMXACBdMgl2Yqc_litXSIukkBQ/view?usp=sharing",
@@ -384,7 +408,7 @@ export const listOfBiblioDigests: BiblioDigestProps[] = [
         serosurveysNonMember: 0,
         publishDate: "2022-01-14",
         screeningStartDate: "2021-12-11",
-        screeningEndDate: "2021-01-07"
+        screeningEndDate: "2022-01-07"
     },
     {
         url: "https://drive.google.com/file/d/1ibebgdbG5C-k0whOJfjeEuECrybmHlQ2/view?usp=sharing",

--- a/src/utils/translate/de.json
+++ b/src/utils/translate/de.json
@@ -292,6 +292,7 @@
     "InsuringTheEconomy": "Absicherung der Wirtschaft gegen eine zweite Pandemiewelle"
   },
   "ResearchArticleTitles": {
+    "MedRxivNLP": "Eine reale Bewertung der Implementierung der NLP-Technologie in einem abstrakten Screening einer systematischen Überprüfung",
     "MedRxivMeta": "Globale Epidemiologie der SARS-CoV-2-Infektion: eine systematische Überprüfung und Metaanalyse standardisierter populationsbasierter Seroprävalenzstudien, Januar 2020 bis Oktober 2021",
     "MedRxivROB": "SeroTracker-ROB: reproduzierbare Entscheidungsregeln zur Risiko-Bias-Bewertung von Seroprävalenzstudien",
     "MedRxivPrivate": "Aufnahme von SARS-CoV-2-Arbeitsplatztestprogrammen, März 2020 bis März 2021",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -295,6 +295,7 @@
     "InsuringTheEconomy": "Insuring the Economy Against a Second Pandemic Wave"
   },
   "ResearchArticleTitles": {
+    "MedRxivNLP": "A real-world evaluation of the implementation of NLP technology in abstract screening of a systematic review",
     "MedRxivMeta": "Global epidemiology of SARS-CoV-2 infection: a systematic review and meta-analysis of standardized population-based seroprevalence studies, Jan 2020-Oct 2021",
     "MedRxivROB": "SeroTracker-ROB: reproducible decision rules for risk of bias assessment of seroprevalence studies",
     "MedRxivPrivate": "Uptake of SARS-CoV-2 workplace testing programs, March 2020 to March 2021",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -290,6 +290,7 @@
     "InsuringTheEconomy": "Assurer l'économie contre une deuxième vague de pandémie"
   },
   "ResearchArticleTitles": {
+    "MedRxivNLP": "Une évaluation dans le monde réel de la mise en œuvre de la technologie PNL dans la sélection abstraite d'une revue systématique",
     "MedRxivMeta": "Épidémiologie mondiale de l'infection par le SRAS-CoV-2: une revue systématique et une méta-analyse d'études de séroprévalence standardisées basées sur la population, janvier 2020-octobre 2021",
     "MedRxivROB": "SeroTracker-ROB: règles de décision reproductibles pour l'évaluation du risque de biais des études de séroprévalence",
     "MedRxivPrivate": "Adoption des programmes de dépistage du SRAS-CoV-2 sur le lieu de travail, mars 2020 à mars 2021",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -290,7 +290,7 @@
     "InsuringTheEconomy": "Assurer l'économie contre une deuxième vague de pandémie"
   },
   "ResearchArticleTitles": {
-    "MedRxivNLP": "Une évaluation dans le monde réel de la mise en œuvre de la technologie PNL dans la sélection abstraite d'une revue systématique",
+    "MedRxivNLP": "Une évaluation concrète de la mise en oeuvre de la technologie NLP dans le triage d'abstraits pour une revue systématique",
     "MedRxivMeta": "Épidémiologie mondiale de l'infection par le SRAS-CoV-2: une revue systématique et une méta-analyse d'études de séroprévalence standardisées basées sur la population, janvier 2020-octobre 2021",
     "MedRxivROB": "SeroTracker-ROB: règles de décision reproductibles pour l'évaluation du risque de biais des études de séroprévalence",
     "MedRxivPrivate": "Adoption des programmes de dépistage du SRAS-CoV-2 sur le lieu de travail, mars 2020 à mars 2021",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
- Adding one new paper and march biblio to pubs page and fixing year of previous biblio card from 2021 to 2022

## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
