### PR TITLE
Qa

### DIFF
--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -81,7 +81,7 @@ export default function Explore({initialFilters}: ExploreProps) {
                             </div>
                             <Icon link onClick={() => {setShowUnityBanner(false)}} name='close'/>
                     </div>)}
-                        <div className="flex w-100">
+                        <div className="flex h-100 w-100">
                             <div className="col-2 p-0 flex">
                                 <LeftSidebar page={PageStateEnum.explore}/>
                             </div>

--- a/src/components/pages/TermsOfUse.tsx
+++ b/src/components/pages/TermsOfUse.tsx
@@ -10,39 +10,39 @@ export default function TermsOfUse() {
   return (
     <div className="col-12 page fill terms pb-2">
       <div className={isMobileDeviceOrTablet ? "static-mobile" : "static-content"}>
-        <h1 className="col-12 p-0">
+        <h1 className="col-12 pb-2">
           {Translate('TermsOfUse')}
         </h1>
-        <div className="col-12 p-0">
-          <p>{Translate('WhoSerotrackAndPartnersDisclaimer1')}</p>
-          <p>{Translate('WhoSerotrackAndPartnersDisclaimer2')}</p>
-          <p>{Translate('WhoSerotrackAndPartnersDisclaimer3')}</p>
+        <div className="col-12 pb-3">
+          <p className={"p-2"}>{Translate('WhoSerotrackAndPartnersDisclaimer1')}</p>
+          <p className={"p-2"}>{Translate('WhoSerotrackAndPartnersDisclaimer2')}</p>
+          <p className={"p-2"}>{Translate('WhoSerotrackAndPartnersDisclaimer3')}</p>
         </div>
 
-        <h3 className="col-12 p-0">
+        <h3 className="col-12 p-2">
           {Translate('DisclaimerListHeader')}
         </h3>
         <ol>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList1')}
           </li>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList2')}
           </li>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList3')}
           </li>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList4')}
           </li>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList5')}
           </li>
-          <li>
+          <li className={"p-2"}>
             {Translate('DisclaimerList6')}
           </li>
         </ol>
-        <div>
+        <div className={"pb-2"}>
           {Translate('DisclaimerFooter')}
         </div>
       </div>

--- a/src/components/pages/static.css
+++ b/src/components/pages/static.css
@@ -164,15 +164,23 @@
   width: 100% !important;
   height: 100%;
   border: 0px;
+
 }
 
 .policy-div-desktop {
-  height: 100%;
-  width: 100%; 
-  margin-left: 40vh !important;
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  box-sizing: border-box;
 }
 
 .policy-div-mobile {
   height: 100%;
   width: 100%;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- Fixed blank areas on WHO unity screen for large websites
- fixed the vertical spacing issue on terms of use page
- fixed horizontal scroll issue on the privacy and cookie pages

## Please link the Airtable ticket associated with this PR.

https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/reczyQkpLMjt3kRx9?blocks=hide
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recWBOaiHi10h655o?blocks=hide
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recPmksXtPfXQsUDK?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

Visible screening of the webpages affected on a varying screen size. 

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
