### PR TITLE
added differentiating factor in key

### DIFF
--- a/src/components/pages/Partnerships/CanadaPartnership.tsx
+++ b/src/components/pages/Partnerships/CanadaPartnership.tsx
@@ -11,8 +11,9 @@ type CanadaPartnershipProps = {
 
 export default function CanadaPartnership({partnershipConfig}:CanadaPartnershipProps) {
   const [state] = useContext(AppContext);
+    console.log(partnershipConfig.tableauKey + state.language)
 
-  return (
+    return (
     <>
       <h1 className="mt-5">{Translate("PartnershipsPageTitle", [partnershipConfig.routeName])}</h1>
       <div className="mt-2">
@@ -36,7 +37,7 @@ export default function CanadaPartnership({partnershipConfig}:CanadaPartnershipP
       <TableauEmbed
         className="row"
         url={partnershipConfig.tableauUrl}
-        key={partnershipConfig.tableauKey}
+        key={partnershipConfig.tableauKey + state.language}
         desktopOptions={{
           width: "100%",
           height: "3100px",

--- a/src/components/shared/TableauEmbed/TableauEmbed.tsx
+++ b/src/components/shared/TableauEmbed/TableauEmbed.tsx
@@ -27,6 +27,7 @@ interface TableauEmbedProps {
 export default function TableauEmbed(props: TableauEmbedProps) {
     const [{ language }, dispatch] = useContext(AppContext);
     const isMobileDeviceOrTablet = useMediaQuery({ maxWidth: mobileDeviceOrTabletWidth });
+    console.log(props.url)
     const url = language in props.url ? props.url[language as LanguageType] : props.url["en"];
 
     let options = {}


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.

- The translations on the partnerships page were offset by one. This fixes that and syncs up the translations. 

## Please link the Airtable ticket associated with this PR.

https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recce1i0nRQsHBudz?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

tried rep[roducing the error. could not reproduce.
Tried alternative ways to reproduce error. could not reproduce. 

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
