### PR TITLE
Himanshu/sidebar new

### DIFF
--- a/src/components/map/Legend.css
+++ b/src/components/map/Legend.css
@@ -4,7 +4,7 @@
   position: absolute;
   width: 180px;
   bottom: 10px;
-  right: 10px;
+  left: 10px;
   z-index: 500;
 }
 

--- a/src/components/map/MapboxMap.tsx
+++ b/src/components/map/MapboxMap.tsx
@@ -68,7 +68,7 @@ const MapboxMap = ( {mapConfig, countriesConfig, studyPinsConfig}: MapboxMapProp
         ...mapConfig,
       };
 
-      const m = new mapboxgl.Map(mergedOptions).addControl(new mapboxgl.NavigationControl());
+      const m = new mapboxgl.Map(mergedOptions).addControl(new mapboxgl.NavigationControl(), "top-left");
 
       m.on("load", () => {
         mapOnLoad(m, dispatch);

--- a/src/components/pages/Explore/Explore.scss
+++ b/src/components/pages/Explore/Explore.scss
@@ -36,10 +36,13 @@
 }
 
 .left-sidebar {
+    justify-content: center;
+    align-content: center;
     position: absolute;
-    left: 10px;
+    left: -16.666vw;
     top: 10px;
     height: calc(100% - 20px);
+    transition: left 0.3s ease-in-out;
     z-index: 999;
     background: rgba(255, 255, 255, 0.5);
     backdrop-filter: blur(30px);
@@ -52,10 +55,15 @@
     }
 }
 
+.left-sidebar.open {
+    left: 10px;
+}
+
 .right-sidebar {
     position: absolute;
-    right: 10px;
     top: 10px;
+    right: -16.66vw;
+    transition: right 0.3s ease-in-out;
     height: calc(100% - 20px);
     z-index: 999;
     background: rgba(255, 255, 255, 0.5);
@@ -68,3 +76,36 @@
         display: none;
     }
 }
+
+.right-sidebar.open {
+    right: 10px;
+}
+
+.show{
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    width: 30px;
+    background-color: rgba(0, 0, 0, 0.2);
+    height: 20vh;
+    top: 40vh;
+    z-index: 100;
+
+    &-left {
+        left: 0;
+        border-radius: 0 10px 10px 0 ;
+    }
+
+    &-right {
+        right: 0;
+        border-radius: 10px 0 0 10px;
+    }
+
+    &:hover {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+}
+
+

--- a/src/components/pages/Explore/Explore.scss
+++ b/src/components/pages/Explore/Explore.scss
@@ -42,7 +42,7 @@
     left: -16.666vw;
     top: 10px;
     height: calc(100% - 20px);
-    transition: left 0.3s ease-in-out;
+    transition: left 0.2s ease-in-out;
     z-index: 999;
     background: rgba(255, 255, 255, 0.5);
     backdrop-filter: blur(30px);
@@ -63,7 +63,7 @@
     position: absolute;
     top: 10px;
     right: -16.66vw;
-    transition: right 0.3s ease-in-out;
+    transition: right 0.2s ease-in-out;
     height: calc(100% - 20px);
     z-index: 999;
     background: rgba(255, 255, 255, 0.5);
@@ -81,30 +81,46 @@
     right: 10px;
 }
 
-.show{
+.sidebar-toggle-button{
     position: absolute;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     width: 30px;
-    background-color: rgba(0, 0, 0, 0.2);
+    background-color: rgba(54, 78, 96, 0.75);
     height: 20vh;
-    top: 40vh;
+    top: 30vh;
     z-index: 100;
+    color: white;
 
-    &-left {
+
+    &-left-close {
         left: 0;
-        border-radius: 0 10px 10px 0 ;
+        transition: left 0.2s ease-in-out;
+        border-radius: 0 10px 10px 0;
     }
 
-    &-right {
+    &-left-open {
+        left: calc(16.66vw + 6.5px);
+        transition: left 0.2s ease-in-out;
+        border-radius: 0 10px 10px 0;
+    }
+
+    &-right-close {
         right: 0;
+        transition: right 0.2s ease-in-out;
+        border-radius: 10px 0 0 10px;
+    }
+
+    &-right-open {
+        right: calc(16.66vw + 6.5px);
+        transition: right 0.2s ease-in-out;
         border-radius: 10px 0 0 10px;
     }
 
     &:hover {
-        background-color: rgba(0, 0, 0, 0.5);
+        background-color: rgba(54, 78, 96, 1);
     }
 }
 

--- a/src/components/pages/Explore/Explore.scss
+++ b/src/components/pages/Explore/Explore.scss
@@ -11,6 +11,9 @@
   }
 
 .explore {
+
+    position: relative;
+
     .sidebar {
         &__info-btn {
             @include icon-container;
@@ -29,5 +32,39 @@
             bottom: 10px;
             right: 10px;
         }
+    }
+}
+
+.left-sidebar {
+    position: absolute;
+    left: 10px;
+    top: 10px;
+    height: calc(100% - 20px);
+    z-index: 999;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(30px);
+    padding-left: 10px;
+    border-radius: 10px;
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+    &::-webkit-scrollbar {
+        display: none;
+    }
+}
+
+.right-sidebar {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    height: calc(100% - 20px);
+    z-index: 999;
+    background: rgba(255, 255, 255, 0.5);
+    backdrop-filter: blur(30px);
+    border-radius: 10px;
+    -ms-overflow-style: none;  /* IE and Edge */
+    scrollbar-width: none;  /* Firefox */
+
+    &::-webkit-scrollbar {
+        display: none;
     }
 }

--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -81,11 +81,11 @@ export default function Explore({initialFilters}: ExploreProps) {
                             </div>
                             <Icon link onClick={() => {setShowUnityBanner(false)}} name='close'/>
                     </div>)}
-                        <div className="flex h-100 w-100">
-                            <div className="col-2 p-0 flex">
+                        <div className="flex h-100 w-100 explore">
+                            <div className="left-sidebar col-2 px-2 py-0 flex sidebar-container">
                                 <LeftSidebar page={PageStateEnum.explore}/>
                             </div>
-                            <div className="col-8 p-0 flex" id={PAGE_HASHES.Explore.Map}>
+                            <div className="map-section col-12 p-0 flex" id={PAGE_HASHES.Explore.Map}>
                                 <Loader indeterminate active={state.explore.isLoading}/>
                                 <div className="info flex legend center-item">
                                     <Legend/>
@@ -99,7 +99,7 @@ export default function Explore({initialFilters}: ExploreProps) {
                                     }}
                                 />
                             </div>
-                            <div className="col-2 p-0 flex sidebar-container">
+                            <div className="col-2 p-0 flex right-sidebar sidebar-container">
                                 <Filters page={PageStateEnum.explore}/>
                             </div>
                         </div>

--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -23,6 +23,15 @@ export default function Explore({initialFilters}: ExploreProps) {
     const [state, dispatch] = useContext(AppContext);
     const [showUnityBanner, setShowUnityBanner] = useState(false);
     const [mobileModalOpen, setMobileModalOpen] = useState(isMobileDeviceOrTablet);
+    const [showSidebar, setShowSidebar] = useState({left: true, right: true});
+
+    const toggleLeftSidebar = () => {
+        setShowSidebar({left: !showSidebar.left, right: showSidebar.right})
+    }
+
+    const toggleRightSidebar = () => {
+        setShowSidebar({left: showSidebar.left, right: !showSidebar.right})
+    }
 
     // Apply initial input filters and get records
     useEffect(() => {
@@ -81,10 +90,14 @@ export default function Explore({initialFilters}: ExploreProps) {
                             </div>
                             <Icon link onClick={() => {setShowUnityBanner(false)}} name='close'/>
                     </div>)}
-                        <div className="flex h-100 w-100 explore">
-                            <div className="left-sidebar col-2 px-2 py-0 flex sidebar-container">
-                                <LeftSidebar page={PageStateEnum.explore}/>
+                        <div className="flex h-100 w-100 explore" style={{overflow: "hidden"}}>
+                            <div className = {"col-2 px-2 py-0 flex sidebar-container left-sidebar " + (showSidebar.left ? "open" : "")}>
+                                <LeftSidebar page={PageStateEnum.explore} toggleSidebar={toggleLeftSidebar}/>
                             </div>
+                            <div className={"show show-left"} onClick={toggleLeftSidebar} style={{visibility : (showSidebar.left ? "hidden" : "visible")}}>
+                                <Icon name={"angle right"} />
+                            </div>
+                            {/*<Button onClick={() => {setShowSidebar({left: !showSidebar.left, right: !showSidebar.right})}}>Show Sidebars</Button>*/}
                             <div className="map-section col-12 p-0 flex" id={PAGE_HASHES.Explore.Map}>
                                 <Loader indeterminate active={state.explore.isLoading}/>
                                 <div className="info flex legend center-item">
@@ -99,8 +112,11 @@ export default function Explore({initialFilters}: ExploreProps) {
                                     }}
                                 />
                             </div>
-                            <div className="col-2 p-0 flex right-sidebar sidebar-container">
-                                <Filters page={PageStateEnum.explore}/>
+                            <div className={"show show-right"} onClick={toggleRightSidebar} style={{visibility : (showSidebar.right ? "hidden" : "visible")}}>
+                                <Icon name={"angle left"} />
+                            </div>
+                            <div className={"col-2 p-0 flex sidebar-container right-sidebar" + (showSidebar.right ? " open" : "")}>
+                                <Filters page={PageStateEnum.explore} toggleSidebar={toggleRightSidebar}/>
                             </div>
                         </div>
                     </>) :

--- a/src/components/pages/Explore/Explore.tsx
+++ b/src/components/pages/Explore/Explore.tsx
@@ -23,7 +23,7 @@ export default function Explore({initialFilters}: ExploreProps) {
     const [state, dispatch] = useContext(AppContext);
     const [showUnityBanner, setShowUnityBanner] = useState(false);
     const [mobileModalOpen, setMobileModalOpen] = useState(isMobileDeviceOrTablet);
-    const [showSidebar, setShowSidebar] = useState({left: true, right: true});
+    const [showSidebar, setShowSidebar] = useState({left: false, right: true});
 
     const toggleLeftSidebar = () => {
         setShowSidebar({left: !showSidebar.left, right: showSidebar.right})
@@ -94,10 +94,9 @@ export default function Explore({initialFilters}: ExploreProps) {
                             <div className = {"col-2 px-2 py-0 flex sidebar-container left-sidebar " + (showSidebar.left ? "open" : "")}>
                                 <LeftSidebar page={PageStateEnum.explore} toggleSidebar={toggleLeftSidebar}/>
                             </div>
-                            <div className={"show show-left"} onClick={toggleLeftSidebar} style={{visibility : (showSidebar.left ? "hidden" : "visible")}}>
-                                <Icon name={"angle right"} />
+                            <div className={("sidebar-toggle-button sidebar-toggle-button-left-" + (showSidebar.left ? "open" : "close"))} onClick={toggleLeftSidebar}>
+                                {showSidebar.left ? <Icon name={"angle left"} /> : <Icon name={"angle right"} />}
                             </div>
-                            {/*<Button onClick={() => {setShowSidebar({left: !showSidebar.left, right: !showSidebar.right})}}>Show Sidebars</Button>*/}
                             <div className="map-section col-12 p-0 flex" id={PAGE_HASHES.Explore.Map}>
                                 <Loader indeterminate active={state.explore.isLoading}/>
                                 <div className="info flex legend center-item">
@@ -112,8 +111,8 @@ export default function Explore({initialFilters}: ExploreProps) {
                                     }}
                                 />
                             </div>
-                            <div className={"show show-right"} onClick={toggleRightSidebar} style={{visibility : (showSidebar.right ? "hidden" : "visible")}}>
-                                <Icon name={"angle left"} />
+                            <div className={("sidebar-toggle-button sidebar-toggle-button-right-" + (showSidebar.right ? "open" : "close"))} onClick={toggleRightSidebar}>
+                                {showSidebar.right ? <Icon name={"angle right"} /> : <Icon name={"angle left"} />}
                             </div>
                             <div className={"col-2 p-0 flex sidebar-container right-sidebar" + (showSidebar.right ? " open" : "")}>
                                 <Filters page={PageStateEnum.explore} toggleSidebar={toggleRightSidebar}/>

--- a/src/components/pages/Explore/ExploreMobile.tsx
+++ b/src/components/pages/Explore/ExploreMobile.tsx
@@ -40,7 +40,7 @@ export default function ExploreMobile() {
           visible={showMobileFilters}
           width='wide'
         >
-        <Filters page={PageStateEnum.explore} />
+        <Filters page={PageStateEnum.explore}  toggleSidebar={() => {}}/>
           <FontAwesomeIcon
             icon={faTimes}
             onClick={() => handleFilterToggle()}
@@ -66,7 +66,7 @@ export default function ExploreMobile() {
             color={'#455a64'}
             style={{ fontWeight: 300, position: 'absolute', zIndex: 3000, top: 10, right: 20 }}
             size={"lg"} />
-          <LeftSidebar page={PageStateEnum.explore}/>
+          <LeftSidebar page={PageStateEnum.explore} toggleSidebar={() => {}}/>
         </Sidebar>
         <Sidebar
           as={Menu}

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -68,7 +68,6 @@ export default function LeftSidebar({ page, toggleSidebar }: SideBarProps) {
 
   return (
     <>
-        <Button className={"mt-2"} onClick={toggleSidebar} style={{width: "100%"}}> Collapse </Button>
       <TotalStats page={page} />
       <Divider />
       <div className="mt-3 mb-2 center subheading">

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useState } from "react";
+import React, {Dispatch, useContext, useState, SetStateAction} from "react";
 import Translate, { TranslateDate } from "utils/translate/translateService";
 import TotalStats from "./TotalStats";
-import { Divider } from "semantic-ui-react";
+import { Divider, Button } from "semantic-ui-react";
 import DownloadButton from "components/shared/DownloadButton";
 import { PAGE_HASHES } from "../../../constants";
 import { IconName } from "../../../types";
@@ -12,6 +12,7 @@ import { mobileDeviceOrTabletWidth } from "../../../constants";
 
 interface SideBarProps {
   page: string;
+    toggleSidebar: () => void;
 }
 
 const UpdatedAt = ({ updatedAt }: { updatedAt: string }) => {
@@ -43,7 +44,7 @@ const Citation = () => (
   </span>
 );
 
-export default function LeftSidebar({ page }: SideBarProps) {
+export default function LeftSidebar({ page, toggleSidebar }: SideBarProps) {
   const [{ updatedAt }] = useContext(AppContext);
 
   const airtableDownloadProps = {
@@ -67,6 +68,7 @@ export default function LeftSidebar({ page }: SideBarProps) {
 
   return (
     <>
+        <Button className={"mt-2"} onClick={toggleSidebar} style={{width: "100%"}}> Collapse </Button>
       <TotalStats page={page} />
       <Divider />
       <div className="mt-3 mb-2 center subheading">

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -66,7 +66,7 @@ export default function LeftSidebar({ page }: SideBarProps) {
   };
 
   return (
-    <div className="sidebar-container flex left-sidebar">
+    <>
       <TotalStats page={page} />
       <Divider />
       <div className="mt-3 mb-2 center subheading">
@@ -99,6 +99,6 @@ export default function LeftSidebar({ page }: SideBarProps) {
           <UpdatedAt updatedAt={updatedAt} />
         </p>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -138,7 +138,6 @@ export default function Filters({ page, toggleSidebar }: FilterProps) {
 
   return (
     <div className="col-12 py-0 px-2">
-      <Button className={"mt-2"} onClick={toggleSidebar} style={{width: "100%"}}> Collapse </Button>
       <div className="py-3 center flex">
         <div className="subheading">
           {Translate("Filter")}

--- a/src/components/sidebar/right-sidebar/Filters.tsx
+++ b/src/components/sidebar/right-sidebar/Filters.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, {Dispatch, SetStateAction, useContext, useState} from "react";
 import { Dropdown, Button } from 'semantic-ui-react';
 import { AppContext } from "../../../context";
 import { FilterType, PageState, State } from '../../../types';
@@ -13,7 +13,8 @@ import "./Filters.css";
 import { LanguageType } from "../../../types";
 
 interface FilterProps {
-  page: string,
+  page: string;
+  toggleSidebar: () => void;
 }
 
 interface PopulationGroupFilterOption {
@@ -22,7 +23,7 @@ interface PopulationGroupFilterOption {
   french: string
 }
 
-export default function Filters({ page }: FilterProps) {
+export default function Filters({ page, toggleSidebar }: FilterProps) {
   const [state, dispatch] = useContext(AppContext);
   const filters = (state[page as keyof State] as PageState).filters;
 
@@ -136,7 +137,8 @@ export default function Filters({ page }: FilterProps) {
   }
 
   return (
-    <div className="col-12 p-0">
+    <div className="col-12 py-0 px-2">
+      <Button className={"mt-2"} onClick={toggleSidebar} style={{width: "100%"}}> Collapse </Button>
       <div className="py-3 center flex">
         <div className="subheading">
           {Translate("Filter")}

--- a/src/components/sidebar/sidebar.scss
+++ b/src/components/sidebar/sidebar.scss
@@ -9,8 +9,3 @@
     width: 3px;
   }
 }
-
-.left-sidebar {
-  font-size: 14px;
-  line-height: 21px;
-}


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Redisgn the side bar
- make it collapsible
- detach from the sides
- create a translucent glossy effect
## Please link the Airtable ticket associated with this PR.

https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viw2Kjofxz0J1dHD0/recfRXCWtB8NMAS3Z?blocks=hide

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

<img width="952" alt="image" src="https://user-images.githubusercontent.com/29795835/185512045-ff89ec7f-9958-44b9-8c6f-1fc68710020d.png">


## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
