### PR TITLE
Explore page height cutoff

### DIFF
--- a/src/components/pages/static.css
+++ b/src/components/pages/static.css
@@ -16,7 +16,7 @@
 }
 
 .dashboard {
-  max-height: calc(100% - 50px);
+  max-height: calc(100vh - 50px);
   height: 100%;
   overflow-y: scroll;
 }


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
The Explore.tsx component has a height of 100vh, we need to reduce that to account for the header so that it does not cut out the page
## Please link the Airtable ticket associated with this PR.
https://airtable.com/appT8tnLbGJV6v81V/tbli2lWQHAqBa6ZcI/viwFS5nE6gepmRwVB/rec8p3hYMDlHfiLnc?blocks=hide
## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.
- Open home page of the serotracker web app
- Change window size and notice the explore component changes with window and remains within the view of the page without scrolling
## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
