### PR TITLE
updated text and added new text

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,15 +28,21 @@ function App() {
   useEffect(() => {
     const api = new httpClient()
     const allFilterOptions = async () => {
-      const { options, updatedAt, maxDate, minDate } = await api.getAllFilterOptions();
+      const { options, lastUpdated, maxDate, minDate, mostRecentPubDate } = await api.getAllFilterOptions();
+
       dispatch({
         type: 'GET_ALL_FILTER_OPTIONS',
         payload: options
       })
 
       dispatch({
-        type: "UPDATED_AT",
-        payload: updatedAt
+        type: "LAST_UPDATED",
+        payload: lastUpdated
+      })
+
+      dispatch({
+        type: "MOST_RECENT_PUB",
+        payload: mostRecentPubDate
       })
 
       dispatch({

--- a/src/components/shared/Footer/Footer.tsx
+++ b/src/components/shared/Footer/Footer.tsx
@@ -20,11 +20,11 @@ type UpdatedAtProps = {
 }
 //TODO: update footer design for mobile
 export const Footer = () => {
-  const [{updatedAt}] = useContext(AppContext);
+  const [{lastUpdated}] = useContext(AppContext);
 
   const isMobileDeviceOrTablet = useMediaQuery({ maxDeviceWidth: mobileDeviceOrTabletWidth });
 
-  return isMobileDeviceOrTablet ? renderMobileFooter(updatedAt) : renderDesktopFooter()
+  return isMobileDeviceOrTablet ? renderMobileFooter(lastUpdated) : renderDesktopFooter()
 }
 
 const renderDesktopFooter = () => {

--- a/src/components/sidebar/left-sidebar/LeftSidebar.tsx
+++ b/src/components/sidebar/left-sidebar/LeftSidebar.tsx
@@ -14,13 +14,22 @@ interface SideBarProps {
   page: string;
 }
 
-const UpdatedAt = ({ updatedAt }: { updatedAt: string }) => {
-  return updatedAt ? (
+const LastUpdated = ({ lastUpdated }: { lastUpdated: string }) => {
+    return lastUpdated ? (
     <span className="pr-2">
       {Translate("Footer", ["LastUpdated"])}:{" "}
-      <b className="updated-at-bold">{TranslateDate(updatedAt)}</b>
+      <b className="updated-at-bold">{TranslateDate(lastUpdated)}</b>
     </span>
   ) : null;
+};
+
+const MostRecentPubDate = ({ mostRecentPubDate }: { mostRecentPubDate: string }) => {
+    return mostRecentPubDate ? (
+        <span className="pr-2">
+      {Translate("Footer", ["MostRecentPubDate"])}:{" "}
+            <b className="updated-at-bold">{TranslateDate(mostRecentPubDate)}</b>
+    </span>
+    ) : null;
 };
 
 const lancetId =
@@ -42,7 +51,7 @@ const Citation = () => (
 );
 
 export default function LeftSidebar({ page }: SideBarProps) {
-  const [{ updatedAt }] = useContext(AppContext);
+  const [{ lastUpdated, mostRecentPubDate }] = useContext(AppContext);
 
   const airtableDownloadProps = {
     buttonLabelKey: "DownloadCsv",
@@ -94,8 +103,11 @@ export default function LeftSidebar({ page }: SideBarProps) {
           <Citation /> 
         </p>
         <p>
-          <UpdatedAt updatedAt={updatedAt} />
+          <LastUpdated lastUpdated={lastUpdated} />
         </p>
+          <p>
+              <MostRecentPubDate mostRecentPubDate={mostRecentPubDate} />
+          </p>
       </div>
     </div>
   );

--- a/src/context.tsx
+++ b/src/context.tsx
@@ -48,7 +48,8 @@ const initialState: State = {
     maxDate: initialMaxDate,
   },
   language: LanguageType.english,
-  updatedAt: "",
+  lastUpdated: "",
+  mostRecentPubDate: "",
   showCookieBanner: false,
   pulsateUnityFilter: false,
 };
@@ -89,10 +90,15 @@ const reducer = (state: State, action: Record<string, any>): State => {
       pageState.records = records;
       return newState;
     }
-    case "UPDATED_AT":
+    case "LAST_UPDATED":
       return {
         ...state,
-        updatedAt: action.payload,
+        lastUpdated: action.payload,
+      };
+    case "MOST_RECENT_PUB":
+      return {
+        ...state,
+        mostRecentPubDate: action.payload,
       };
     case "UPDATE_FILTER": {
       const { pageStateEnum, filterType, filterValue } = action.payload;

--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -82,14 +82,15 @@ export default class httpClient {
         const options: Record<string, any> = response;
         // We know that only these 3 isotypes will ever be reported, thus we can hardcode
         options.isotypes_reported = ["IgG", "IgA", "IgM"];
-        const updatedAt = format(parseISO(response.updated_at), "yyyy/MM/dd");
+        const lastUpdated = format(parseISO(response.last_updated), "yyyy/MM/dd");
+        const mostRecentPubDate = format(parseISO(response.most_recent_publication_date), "yyyy/MM/dd")
 
         const maxDate = parseISO(response.max_publication_end_date);
         const minDate = parseISO(response.min_publication_end_date);
         delete options.min_date;
         delete options.max_date;
 
-        return { options, updatedAt, maxDate, minDate };
+        return { options, lastUpdated, maxDate, minDate, mostRecentPubDate };
     }
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,7 +92,8 @@ export type State = {
   chartAggregationFactor: AggregationFactor;
   explore: PageState;
   allFilterOptions: FiltersConfig;
-  updatedAt: string;
+  lastUpdated: string;
+  mostRecentPubDate: string;
   calendarStartDates: StartDates;
   language: LanguageType;
   showCookieBanner: boolean;

--- a/src/utils/translate/de.json
+++ b/src/utils/translate/de.json
@@ -241,9 +241,11 @@
   "For": "Für",
   "Footer": {
     "CiteAs": "Zitieren Sie bitte als:",
-    "LastUpdated": "Datenbank aktuell bis",
+    "LastUpdated": "Datenbank zuletzt aktualisiert",
     "LancetInfDis": "Lancet Inf Dis",
-    "Article": "Artikel"
+    "Article": "Artikel",
+    "MostRecentPubDate": "Zuletzt veröffentlichte Studie"
+
   },
   "French": "Français",
   "FAQ": "FAQ",

--- a/src/utils/translate/en.json
+++ b/src/utils/translate/en.json
@@ -245,9 +245,10 @@
   "For": "For",
   "Footer": {
     "CiteAs": "Cite as: ",
-    "LastUpdated": "Database up to date to",
+    "LastUpdated": "Database last updated",
     "LancetInfDis": "Lancet Inf Dis",
-    "Article": "article"
+    "Article": "article",
+    "MostRecentPubDate": "Most recently published study"
   },
   "French": "Français",
   "FAQ": "FAQ",

--- a/src/utils/translate/fr.json
+++ b/src/utils/translate/fr.json
@@ -240,9 +240,10 @@
   "For": "Pour",
   "Footer": {
     "CiteAs": "Citez ceci comme: ",
-    "LastUpdated": "Base de données à jour jusqu'au",
+    "LastUpdated": "Base de données mise à jour pour la dernière fois",
     "LancetInfDis": "Lancet Inf Dis",
-    "Article": "article"
+    "Article": "article",
+    "MostRecentPubDate": "Étude la plus récemment publiée"
   },
   "French": "français",
   "FAQ": "FAQ",


### PR DESCRIPTION
## Briefly describe the feature or bug that this PR addresses.
Updated UI to display most recent pub date as well as the last updated date
## Please link the Airtable ticket associated with this PR.

## If applicable, include screenshots of the feature/bugfix introduced by this PR (Please include both desktop and mobile if there is a significant UI change).

## Describe the steps you took to test the feature/bugfix introduced by this PR.

## Does this PR depend on any recent backend work? If so, please include the PR number from the iit-backend repo and associated Airtable ticket link.

## Does this PR require any French translations? Have they been included?

## QA checklist: complete all parts relevant to your ticket changes

### Explore

- Check Desktop and on Mobile
- Summary Stats
- Map loads in ~8 seconds with loading spinner 
- Map has pins
- Country Modal - check all fields
- Pins modal (check each grade) - check all fields
- Filter info bubbles
- Select each filter and check options
- Execute a Filter for Risk of bias, Sex, and Date.
- Check the "Database up to date to:" date
- Check each footer item (Privacy policy etc.)

### Analyse
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 

### Data
- Click each button
- Click a FAQ for functionality
- References table embed loads
    - Check that downloads are disabled.
- Data download link provides access to a downloadable CSV.
    - Download the CSV
- "terms of use" button

### Publications
- Cards all load with images
- Carousel is clickable
- Try 2 random items on the page for functional links

### About
- Page loads
- Scroll to bottom

### Check serotracker.com/broken
- 404 page loads and animation works

### Check serotracker.com/Canada 
- Check tableau embed loads and is functional
- Check for double scrolling (the embed scrolls within the page) 
- Check in French

### Cycle through all pages in French for any glaring omissions
